### PR TITLE
feat(frontend): add fallback UI for broken dataset images

### DIFF
--- a/frontend/src/components/ui/DatasetCard.tsx
+++ b/frontend/src/components/ui/DatasetCard.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { ShoppingCart, TrendingUp, User, Zap } from 'lucide-react';
+import { ShoppingCart, TrendingUp, User, Zap, Clock, ImageOff } from 'lucide-react';
 import clsx from 'clsx';
 import { DatasetMeta } from '../../lib/api';
-import { truncateAddress, formatUSDC, getTypeMeta } from '../../lib/utils';
+import { truncateAddress, formatUSDC, getTypeMeta, formatTimeAgo } from '../../lib/utils';
 
 interface Props {
   dataset: DatasetMeta;
@@ -11,6 +11,7 @@ interface Props {
 
 export default function DatasetCard({ dataset, onBuy }: Props) {
   const [hovered, setHovered] = useState(false);
+  const [imageError, setImageError] = useState(false);
   const typeMeta = getTypeMeta(dataset.type);
 
   return (
@@ -25,19 +26,53 @@ export default function DatasetCard({ dataset, onBuy }: Props) {
       {/* Top gold shimmer line */}
       <div
         className={clsx(
-          'absolute top-0 left-0 right-0 h-px transition-all duration-500',
+          'absolute top-0 left-0 right-0 h-px transition-all duration-500 z-10',
           hovered ? 'bg-gradient-to-r from-transparent via-gold to-transparent opacity-100' : 'opacity-0'
         )}
       />
 
-      <div className="p-6">
-        {/* Header row */}
-        <div className="flex items-start justify-between gap-3 mb-4">
-          <span className={clsx('type-badge', typeMeta.color, typeMeta.bg)}>
+      {/* Dataset Image */}
+      <div className="relative h-40 overflow-hidden bg-void-2/50 group-hover:bg-void-2/30 transition-colors duration-500 flex items-center justify-center">
+        {imageError ? (
+          <div className="flex flex-col items-center gap-2 text-muted-2">
+            <ImageOff className="w-8 h-8 opacity-20" />
+            <span className="text-[10px] uppercase tracking-tighter opacity-30 font-body">Image unavailable</span>
+          </div>
+        ) : (
+          <>
+            <img
+              src={dataset.thumbnail || `https://source.unsplash.com/featured/?crypto,${dataset.type}`}
+              alt={dataset.name}
+              className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110 opacity-60 group-hover:opacity-80"
+              onError={() => setImageError(true)}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent opacity-60" />
+          </>
+        )}
+        
+        {/* Floating badge over image */}
+        <div className="absolute top-4 left-4 z-10">
+          <span className={clsx('type-badge backdrop-blur-md border border-gold/20 shadow-lg', typeMeta.color, typeMeta.bg)}>
             <Zap className="w-3 h-3" />
             {typeMeta.label}
           </span>
-          <div className="text-right">
+        </div>
+      </div>
+
+      <div className="p-6">
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div className="flex-1">
+            <h3 className="font-display font-semibold text-foreground text-base mb-1 leading-snug line-clamp-1 group-hover:text-gold transition-colors duration-300">
+              {dataset.name}
+            </h3>
+            <div className="flex items-center gap-1.5">
+              <User className="w-3 h-3 text-muted" />
+              <span className="text-[10px] font-mono text-muted-2">
+                {truncateAddress(dataset.sellerWallet)}
+              </span>
+            </div>
+          </div>
+          <div className="text-right flex-shrink-0">
             <p className="text-xs text-muted-2 font-body">per query</p>
             <p className="text-lg font-display font-bold text-gold-gradient">
               ${formatUSDC(dataset.pricePerQuery)}
@@ -45,18 +80,14 @@ export default function DatasetCard({ dataset, onBuy }: Props) {
           </div>
         </div>
 
-        {/* Name */}
-        <h3 className="font-display font-semibold text-foreground text-base mb-2 leading-snug line-clamp-2 group-hover:text-gold transition-colors duration-300">
-          {dataset.name}
-        </h3>
 
         {/* Description */}
-        <p className="text-sm text-foreground-muted font-body leading-relaxed line-clamp-2 mb-5">
+        <p className="text-sm text-foreground-muted font-body leading-relaxed line-clamp-2 mb-5 h-10">
           {dataset.description}
         </p>
 
         {/* Stats */}
-        <div className="flex items-center gap-4 mb-5">
+        <div className="flex items-center gap-4 mb-5 border-t border-border/20 pt-4">
           <div className="flex items-center gap-1.5">
             <TrendingUp className="w-3.5 h-3.5 text-emerald-400" />
             <span className="text-xs font-body text-foreground-muted">
@@ -65,9 +96,9 @@ export default function DatasetCard({ dataset, onBuy }: Props) {
           </div>
           <div className="w-px h-3 bg-border" />
           <div className="flex items-center gap-1.5">
-            <User className="w-3.5 h-3.5 text-muted" />
-            <span className="text-xs font-body text-foreground-muted font-mono">
-              {truncateAddress(dataset.sellerWallet)}
+            <Clock className="w-3.5 h-3.5 text-muted" />
+            <span className="text-xs font-body text-foreground-muted">
+              {formatTimeAgo(dataset.createdAt)}
             </span>
           </div>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,6 +70,7 @@ export interface DatasetMeta {
   queriesServed: number;
   totalEarned: number;
   createdAt: string;
+  thumbnail?: string;
 }
 
 export interface Transaction {

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -6,7 +6,7 @@ import {
 } from 'lucide-react';
 import { api, DatasetMeta } from '../lib/api';
 import { useCountUp } from '../hooks/useCountUp';
-import { formatUSDC, getTypeMeta, truncateAddress } from '../lib/utils';
+import DatasetCard from '../components/ui/DatasetCard';
 import clsx from 'clsx';
 
 function Particle({ style }: { style: React.CSSProperties }) {
@@ -294,27 +294,9 @@ export default function LandingPage() {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              {featured.map((ds) => {
-                const typeMeta = getTypeMeta(ds.type);
-                return (
-                  <div key={ds.id} className="glass-card p-6 group hover:shadow-card-hover hover:border-border-gold/20 transition-all duration-300">
-                    <div className="flex justify-between items-start mb-3">
-                      <span className={clsx('type-badge text-xs', typeMeta.color, typeMeta.bg)}>
-                        {typeMeta.label}
-                      </span>
-                      <span className="text-gold font-display font-bold">${ds.pricePerQuery}</span>
-                    </div>
-                    <h3 className="font-display font-semibold text-foreground mb-2 leading-snug group-hover:text-gold transition-colors">
-                      {ds.name}
-                    </h3>
-                    <p className="text-sm text-foreground-muted mb-4 line-clamp-2">{ds.description}</p>
-                    <div className="flex justify-between text-xs text-muted-2 font-body">
-                      <span>{ds.queriesServed} queries</span>
-                      <span className="font-mono">{truncateAddress(ds.sellerWallet)}</span>
-                    </div>
-                  </div>
-                );
-              })}
+              {featured.map((ds) => (
+                <DatasetCard key={ds.id} dataset={ds} onBuy={() => {}} />
+              ))}
             </div>
 
             <div className="text-center mt-10">


### PR DESCRIPTION
## Description
This PR implements a fallback UI for dataset images. It prevents blank spaces or broken image icons in the frontend when a dataset image URL is invalid, broken, or missing, ensuring a consistent user experience.

**Closes #35**

## Type of Change
- [x] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Tests
- [ ] Infrastructure / CI
- [ ] Documentation

Proofs : 
<img width="1909" height="867" alt="Screenshot 2026-04-25 013033" src="https://github.com/user-attachments/assets/d086296f-7cab-4bcc-8fef-55a08fdbda36" />

