### PR TITLE
[Tooling] Add automated Vercel/Netlify deployment CI

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,102 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/deploy-frontend.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-frontend-main
+  cancel-in-progress: true
+
+jobs:
+  build-frontend:
+    name: Build Frontend Artifact
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          if-no-files-found: error
+
+  deploy-vercel:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+    needs: build-frontend
+    if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pull Vercel settings
+        run: npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build Vercel output
+        run: npx vercel build --prod --token="${{ secrets.VERCEL_TOKEN }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel
+        run: npx vercel deploy --prebuilt --prod --token="${{ secrets.VERCEL_TOKEN }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+  deploy-netlify:
+    name: Deploy to Netlify
+    runs-on: ubuntu-latest
+    needs: build-frontend
+    if: ${{ secrets.NETLIFY_AUTH_TOKEN != '' && secrets.NETLIFY_SITE_ID != '' }}
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: dist
+
+      - name: Deploy to Netlify
+        run: npx netlify-cli deploy --dir=dist --prod --site="${{ secrets.NETLIFY_SITE_ID }}" --auth="${{ secrets.NETLIFY_AUTH_TOKEN }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Hazina is a Web3 data marketplace on Stellar — data sellers list on-chain inte
 - [Branch & Commit Conventions](#branch--commit-conventions)
 - [Code Quality Standards](#code-quality-standards)
 - [Testing Requirements](#testing-requirements)
+- [Deployment CI Secrets](#deployment-ci-secrets)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Issue Labels Explained](#issue-labels-explained)
 - [Getting Help](#getting-help)
@@ -250,6 +251,27 @@ const sellerAmount = dataset.pricePerQuery * (1 - PLATFORM_FEE_BPS / 10_000);
 ## Testing Requirements
 
 Every PR that touches backend logic must include or update tests. PRs with zero test coverage for new code will not be merged.
+
+---
+
+## Deployment CI Secrets
+
+The repository includes `.github/workflows/deploy-frontend.yml` to automate frontend deployment to Vercel and Netlify from `main`.
+
+Add these repository secrets before enabling production deploys:
+
+### Vercel
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+### Netlify
+
+- `NETLIFY_AUTH_TOKEN`
+- `NETLIFY_SITE_ID`
+
+If one provider's secrets are missing, that provider's deploy job is skipped while other jobs can still run.
 
 ### Backend (Vitest)
 


### PR DESCRIPTION
Closes #78
Closes #59
Closes #64
Closes #65

## Changes
- Added .github/workflows/deploy-frontend.yml to build the frontend and deploy automatically from main.
- Added secret-gated deployment jobs for both Vercel and Netlify so either provider can run independently.
- Updated CONTRIBUTING.md with required deployment CI secrets.

## Workflow Behavior
- Triggered on push to main when frontend files (or the deploy workflow) change.
- Supports manual runs with workflow_dispatch.
- Runs uild-frontend first, then deploys to each provider only when that provider's secrets are configured.

## Testing
- Validated workflow YAML structure and repository paths.