### PR TITLE
fix: error boundary labels, Stellar address validation, dashboard error state, search debounce (#135 #136 #137 #138)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,11 +41,11 @@ export default function App() {
       <OnboardingTour />
       <main id="main-content" tabIndex={-1}>
         <Routes>
-          <Route path="/" element={<RouteBoundary><LandingPage /></RouteBoundary>} />
-          <Route path="/marketplace" element={<RouteBoundary><MarketplacePage /></RouteBoundary>} />
-          <Route path="/sell" element={<RouteBoundary><SellPage /></RouteBoundary>} />
-          <Route path="/dashboard" element={<RouteBoundary><DashboardPage /></RouteBoundary>} />
-          <Route path="/agent" element={<RouteBoundary><AgentPage /></RouteBoundary>} />
+          <Route path="/" element={<RouteBoundary label="Landing"><LandingPage /></RouteBoundary>} />
+          <Route path="/marketplace" element={<RouteBoundary label="Marketplace"><MarketplacePage /></RouteBoundary>} />
+          <Route path="/sell" element={<RouteBoundary label="Sell"><SellPage /></RouteBoundary>} />
+          <Route path="/dashboard" element={<RouteBoundary label="Dashboard"><DashboardPage /></RouteBoundary>} />
+          <Route path="/agent" element={<RouteBoundary label="Agent"><AgentPage /></RouteBoundary>} />
           <Route path="*" element={<RouteBoundary><NotFound /></RouteBoundary>} />
         </Routes>
       </main>
@@ -53,8 +53,12 @@ export default function App() {
   );
 }
 
-function RouteBoundary({ children }: { children: ReactNode }) {
-  return <ErrorBoundary>{children}</ErrorBoundary>;
+function RouteBoundary({ children, label }: { children: ReactNode; label?: string }) {
+  return (
+    <ErrorBoundary label={label} onReset={() => window.location.reload()}>
+      {children}
+    </ErrorBoundary>
+  );
 }
 
 function NotFound() {

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,6 +2,10 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 
 type ErrorBoundaryProps = {
   children: ReactNode;
+  /** Optional label shown in the fallback heading for scoped boundaries. */
+  label?: string;
+  /** Called after the user clicks "Try again" on a scoped boundary. */
+  onReset?: () => void;
 };
 
 type ErrorBoundaryState = {
@@ -23,7 +27,12 @@ export default class ErrorBoundary extends Component<
   }
 
   private handleReload = () => {
-    window.location.reload();
+    if (this.props.onReset) {
+      this.setState({ error: null });
+      this.props.onReset();
+    } else {
+      window.location.reload();
+    }
   };
 
   render() {
@@ -32,7 +41,9 @@ export default class ErrorBoundary extends Component<
         <div className="min-h-screen flex items-center justify-center px-4">
           <div className="glass-card max-w-lg w-full p-8 text-center">
             <h2 className="font-display text-2xl font-semibold text-foreground mb-3">
-              Something went wrong
+              {this.props.label
+                ? `Something went wrong in ${this.props.label}`
+                : "Something went wrong"}
             </h2>
             <p className="font-body text-sm text-foreground-muted mb-6 break-words">
               {this.state.error.message || "Unexpected application error"}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -158,16 +158,23 @@ export default function DashboardPage() {
   const [datasets, setDatasets] = useState<DatasetMeta[]>([]);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [walletFilter, setWalletFilter] = useState("");
 
   useEffect(() => {
+    setLoading(true);
+    setFetchError(null);
     Promise.all([api.getDatasets()])
       .then(([ds]) => {
         setDatasets(ds);
-        // Load transactions for all datasets
         return Promise.all(ds.map((d) => api.getTransactions(d.id)));
       })
       .then((txArrays) => setTransactions(txArrays.flat()))
+      .catch((err) => {
+        setFetchError(
+          err instanceof Error ? err.message : "Failed to load dashboard data.",
+        );
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -235,6 +242,26 @@ export default function DashboardPage() {
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="min-h-screen pt-28 flex items-center justify-center px-4">
+        <div className="glass-card max-w-md w-full p-8 text-center">
+          <p className="font-display text-xl font-semibold text-foreground mb-3">
+            {t("dashboard.loadError", "Could not load dashboard")}
+          </p>
+          <p className="text-sm text-foreground-muted font-body mb-6">{fetchError}</p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="btn-gold px-6 py-2.5 text-sm"
+          >
+            {t("common.actions.retry", "Retry")}
+          </button>
         </div>
       </div>
     );

--- a/frontend/src/pages/MarketplacePage.tsx
+++ b/frontend/src/pages/MarketplacePage.tsx
@@ -21,6 +21,9 @@ import { useI18n } from "../i18n";
 
 export default function MarketplacePage() {
   const { locale, t } = useI18n();
+  /** Raw input value — updated on every keystroke. */
+  const [searchInput, setSearchInput] = useState("");
+  /** Debounced value used in the query — updated 400 ms after typing stops. */
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState("");
   const [sort, setSort] = useState("popular");
@@ -29,6 +32,12 @@ export default function MarketplacePage() {
     null,
   );
   const pageSize = 12;
+
+  // Debounce: only update the query key 400 ms after the user stops typing.
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 400);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
   const { data, isLoading: loading, refetch } = useQuery({
     queryKey: ["datasets", page, search, typeFilter, sort],
@@ -107,13 +116,13 @@ export default function MarketplacePage() {
               <input
                 type="text"
                 placeholder={t("marketplace.searchPlaceholder")}
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
                 className="w-full bg-void/60 border border-border/60 rounded-xl pl-11 pr-4 py-3 text-sm font-body text-foreground placeholder:text-muted focus:outline-none focus:border-gold/40 transition-colors"
               />
-              {search && (
+              {searchInput && (
                 <button
-                  onClick={() => setSearch("")}
+                  onClick={() => { setSearchInput(""); setSearch(""); }}
                   className="absolute right-4 top-1/2 -translate-y-1/2 text-muted hover:text-foreground"
                   aria-label={t("common.actions.resetSearch")}
                 >

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -97,12 +97,15 @@ export default function SellPage() {
     reader.readAsText(file);
   };
 
+  const isValidStellarAddress = (addr: string): boolean =>
+    /^G[A-Z2-7]{55}$/.test(addr.trim());
+
   const isValid =
     form.name.trim() &&
     form.description.trim() &&
     form.type &&
     parseFloat(form.pricePerQuery) > 0 &&
-    form.sellerWallet.trim().length >= 56 &&
+    isValidStellarAddress(form.sellerWallet) &&
     form.dataText.trim() &&
     !jsonError;
 
@@ -316,12 +319,12 @@ export default function SellPage() {
                     placeholder={t("sell.form.sellerWalletPlaceholder")}
                     className={clsx(
                       "w-full bg-void/60 border rounded-xl px-4 py-3 text-sm font-mono text-foreground placeholder:text-muted focus:outline-none transition-colors",
-                      form.sellerWallet && form.sellerWallet.length < 56
+                      form.sellerWallet && !isValidStellarAddress(form.sellerWallet)
                         ? "border-red-500/50 focus:border-red-500/70"
                         : "border-border/60 focus:border-gold/50",
                     )}
                   />
-                  {form.sellerWallet && form.sellerWallet.length < 56 && (
+                  {form.sellerWallet && !isValidStellarAddress(form.sellerWallet) && (
                     <p className="text-xs text-red-400 mt-1 font-body">
                       {t("sell.form.sellerWalletError")}
                     </p>


### PR DESCRIPTION
Fixes #135
Fixes #136
Fixes #137
Fixes #138

## What changed

### #135 — React Error Boundary
The root `ErrorBoundary` was already wired in `main.tsx` and every route was already wrapped in a `RouteBoundary` in `App.tsx`. Enhanced the implementation:
- Added `label?: string` prop to `ErrorBoundary` — shown in the fallback heading (e.g. *"Something went wrong in Dashboard"*) so users understand which section failed
- Added `onReset?: () => void` prop for in-place recovery without a full page reload
- `RouteBoundary` in `App.tsx` now passes a label per route: Landing, Marketplace, Sell, Dashboard, Agent

### #136 — Stellar address validation
**`frontend/src/pages/SellPage.tsx`**
- Replaced the `>= 56` length check with a full regex: `/^G[A-Z2-7]{55}$/` via `isValidStellarAddress()` helper
- `isValid` and the inline red error now use the proper check — addresses that are 56+ chars but don't start with `G` or contain invalid base32 characters are now correctly rejected

### #137 — Dashboard loading / error state
**`frontend/src/pages/DashboardPage.tsx`**
- The skeleton loading state already existed. Added the missing error path: `catch` handler sets `fetchError` state
- A friendly error card with a Retry button is shown when the initial data fetch fails — previously a failed fetch would leave a blank screen

### #138 — Search debounce
**`frontend/src/pages/MarketplacePage.tsx`**
- Split `search` into `searchInput` (raw keystroke value) and `search` (debounced query key)
- `useEffect` with `clearTimeout` / 400ms delay updates `search` only after the user stops typing
- The clear button (×) resets both states atomically
- Reduces API calls from one per keystroke to one per typing pause