### PR TITLE
chore: env-driven API base URL + Zod validation on webhooks/backup routers

### DIFF
--- a/backend/src/common/backup.router.ts
+++ b/backend/src/common/backup.router.ts
@@ -1,5 +1,20 @@
 import { Router, Request, Response } from 'express';
+import { z } from 'zod';
 import { BackupScheduler } from './backup.scheduler';
+import { validateBody } from './validate';
+
+const restoreBackupSchema = z.object({
+  filename: z
+    .string()
+    .trim()
+    .min(1, 'filename is required')
+    .max(255, 'filename must be at most 255 characters')
+    .regex(
+      /^[A-Za-z0-9._-]+$/,
+      'filename must contain only letters, numbers, dots, dashes, and underscores',
+    )
+    .refine((value) => !value.includes('..'), 'filename must not contain path traversal sequences'),
+});
 
 let backupScheduler: BackupScheduler | null = null;
 
@@ -104,16 +119,12 @@ backupRouter.post('/backups/create', async (_req: Request, res: Response) => {
  *       200:
  *         description: Backup restored successfully
  */
-backupRouter.post('/backups/restore', async (req: Request, res: Response) => {
+backupRouter.post('/backups/restore', validateBody(restoreBackupSchema), async (req: Request, res: Response) => {
   if (!backupScheduler) {
     return res.status(503).json({ error: 'Backup service not initialized' });
   }
 
-  const { filename } = req.body;
-
-  if (!filename) {
-    return res.status(400).json({ error: 'Filename is required' });
-  }
+  const { filename } = req.body as z.infer<typeof restoreBackupSchema>;
 
   try {
     await backupScheduler.getBackupService().restoreBackup(filename);

--- a/backend/src/common/validate.ts
+++ b/backend/src/common/validate.ts
@@ -5,9 +5,15 @@ export function validateBody(schema: ZodTypeAny) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const result = schema.safeParse(req.body);
     if (!result.success) {
+      const flat = result.error.flatten();
+      const fieldMessages = Object.values(flat.fieldErrors)
+        .flat()
+        .filter((m): m is string => typeof m === 'string' && m.length > 0);
+      const formMessages = flat.formErrors.filter((m) => m.length > 0);
+      const allMessages = [...fieldMessages, ...formMessages];
       res.status(400).json({
-        error: 'Validation failed',
-        fields: result.error.flatten().fieldErrors,
+        error: allMessages.length > 0 ? allMessages.join('; ') : 'Validation failed',
+        fields: flat.fieldErrors,
       });
       return;
     }

--- a/backend/src/webhooks/webhook.router.ts
+++ b/backend/src/webhooks/webhook.router.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
 import {
   WebhookEvent,
   addWebhook,
@@ -8,6 +9,7 @@ import {
   removeWebhook,
   updateWebhook,
 } from '../common/storage';
+import { validateBody } from '../common/validate';
 import { notifySeller } from './webhook.service';
 
 export const webhooksRouter = Router();
@@ -20,50 +22,79 @@ const VALID_EVENTS: WebhookEvent[] = [
   'ping',
 ];
 
-// POST /api/webhooks — register a new webhook
-webhooksRouter.post('/', (req: Request, res: Response) => {
-  const { sellerWallet, url, secret, events } = req.body;
-
-  if (!sellerWallet || typeof sellerWallet !== 'string') {
-    return res.status(400).json({ error: 'sellerWallet is required' });
-  }
-  if (!url || typeof url !== 'string') {
-    return res.status(400).json({ error: 'url is required' });
-  }
-  if (!secret || typeof secret !== 'string') {
-    return res.status(400).json({ error: 'secret is required' });
-  }
-
-  // Validate URL format
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(url);
-  } catch {
-    return res.status(400).json({ error: 'Invalid URL format' });
-  }
-  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-    return res.status(400).json({ error: 'URL must use http or https' });
-  }
-
-  // Validate events
-  let webhookEvents: WebhookEvent[] = [];
-  if (events) {
-    if (!Array.isArray(events)) {
-      return res.status(400).json({ error: 'events must be an array' });
+const webhookUrlField = z
+  .string()
+  .trim()
+  .min(1, 'url is required')
+  .superRefine((value, ctx) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Invalid URL format',
+      });
+      return;
     }
-    const invalid = events.filter((e: string) => !VALID_EVENTS.includes(e as WebhookEvent));
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'URL must use http or https',
+      });
+    }
+  });
+
+const webhookEventsField = z
+  .array(z.string())
+  .superRefine((events, ctx) => {
+    const invalid = events.filter((e) => !VALID_EVENTS.includes(e as WebhookEvent));
     if (invalid.length > 0) {
-      return res.status(400).json({ error: `Invalid events: ${invalid.join(', ')}` });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid events: ${invalid.join(', ')}`,
+      });
     }
-    webhookEvents = events as WebhookEvent[];
-  }
+  })
+  .transform((events) => events as WebhookEvent[]);
+
+const createWebhookSchema = z.object({
+  sellerWallet: z
+    .string({ required_error: 'sellerWallet is required' })
+    .trim()
+    .min(1, 'sellerWallet is required')
+    .max(200),
+  url: webhookUrlField,
+  secret: z.string({ required_error: 'secret is required' }).min(1, 'secret is required').max(500),
+  events: webhookEventsField.optional(),
+});
+
+const updateWebhookSchema = z
+  .object({
+    url: webhookUrlField.optional(),
+    secret: z.string().min(1, 'secret must be a non-empty string').max(500).optional(),
+    events: webhookEventsField.optional(),
+    active: z.boolean().optional(),
+  })
+  .refine(
+    (data) =>
+      data.url !== undefined ||
+      data.secret !== undefined ||
+      data.events !== undefined ||
+      data.active !== undefined,
+    { message: 'At least one of url, secret, events, or active must be provided' },
+  );
+
+// POST /api/webhooks — register a new webhook
+webhooksRouter.post('/', validateBody(createWebhookSchema), (req: Request, res: Response) => {
+  const { sellerWallet, url, secret, events } = req.body as z.infer<typeof createWebhookSchema>;
 
   const webhook = {
     id: `wh-${uuidv4()}`,
     sellerWallet,
     url,
     secret,
-    events: webhookEvents,
+    events: events ?? [],
     active: true,
     createdAt: new Date().toISOString(),
   };
@@ -125,49 +156,13 @@ webhooksRouter.post('/:id/test', async (req: Request, res: Response) => {
 });
 
 // PATCH /api/webhooks/:id — update webhook (url, secret, events, active)
-webhooksRouter.patch('/:id', (req: Request, res: Response) => {
+webhooksRouter.patch('/:id', validateBody(updateWebhookSchema), (req: Request, res: Response) => {
   const webhook = getWebhookById(req.params.id);
   if (!webhook) {
     return res.status(404).json({ error: 'Webhook not found' });
   }
 
-  const { url, secret, events, active } = req.body;
-  const updates: Partial<typeof webhook> = {};
-
-  if (url !== undefined) {
-    try {
-      const parsed = new URL(url);
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return res.status(400).json({ error: 'URL must use http or https' });
-      }
-      updates.url = url;
-    } catch {
-      return res.status(400).json({ error: 'Invalid URL format' });
-    }
-  }
-
-  if (secret !== undefined) {
-    if (typeof secret !== 'string' || secret.length === 0) {
-      return res.status(400).json({ error: 'secret must be a non-empty string' });
-    }
-    updates.secret = secret;
-  }
-
-  if (events !== undefined) {
-    if (!Array.isArray(events)) {
-      return res.status(400).json({ error: 'events must be an array' });
-    }
-    const invalid = events.filter((e: string) => !VALID_EVENTS.includes(e as WebhookEvent));
-    if (invalid.length > 0) {
-      return res.status(400).json({ error: `Invalid events: ${invalid.join(', ')}` });
-    }
-    updates.events = events as WebhookEvent[];
-  }
-
-  if (active !== undefined) {
-    updates.active = Boolean(active);
-  }
-
+  const updates = req.body as z.infer<typeof updateWebhookSchema>;
   const updated = updateWebhook(req.params.id, updates);
   if (!updated) {
     return res.status(500).json({ error: 'Failed to update webhook' });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,9 @@
-const BASE = '/api';
+const RAW_API_URL = (import.meta.env.VITE_API_URL ?? '').toString().trim();
+export const API_BASE_URL = RAW_API_URL
+  ? `${RAW_API_URL.replace(/\/+$/, '')}/api`
+  : '/api';
+
+const BASE = API_BASE_URL;
 
 export interface AgentSellerPayment {
   seller: string;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

Three issues addressed in one PR:

### #155 — Hardcoded API base URL
`frontend/src/lib/api.ts` previously had `const BASE = '/api'`. Now reads `import.meta.env.VITE_API_URL`:

- If `VITE_API_URL` is set → targets `<VITE_API_URL>/api` (works for split frontend/backend deploys)
- If unset → falls back to relative `/api` so the existing Vite dev proxy keeps working

Also adds `frontend/src/vite-env.d.ts` with a typed `ImportMetaEnv` so `import.meta.env.VITE_API_URL` is strictly typed. `frontend/.env.example` already declared this var on `main`.

### #156 — Input validation / sanitization
The `validateBody` middleware + Zod approach was already used by `datasets`, `payments`, and `agent` routers, but `webhooks` and `backup` still used manual `typeof` / `try { new URL() }` checks. This PR:

- **`webhooks.router.ts`**: extracts `createWebhookSchema` and `updateWebhookSchema` (URL must be `http`/`https`, events restricted to the `VALID_EVENTS` set, PATCH must change at least one field). POST `/` and PATCH `/:id` now go through `validateBody`.
- **`backup.router.ts`**: adds `restoreBackupSchema` for POST `/backups/restore` — filename is bounded length, restricted to `[A-Za-z0-9._-]+`, and explicitly rejects `..` to block path traversal.
- **`common/validate.ts`**: enriches `validateBody` to flatten field-level Zod messages into the top-level `error` string (e.g. `error: \"Invalid events: foo\"`) so the JSON shape stays useful for consumers; `fields` still surfaces the per-field array.

### #140 — Pagination for marketplace datasets
**Already implemented on `main`.** GET `/api/datasets` accepts `page`/`limit`/`search`/`type`/`sort` and returns `{ data, total, page, totalPages }` (`backend/src/datasets/datasets.router.ts:172-222`). The frontend `MarketplacePage` (`frontend/src/pages/MarketplacePage.tsx`) drives the page state, prev/next buttons, visible-page-number window, and a per-page items count via react-query (`useQuery(['datasets', page, search, typeFilter, sort], ...)`). No code change needed; closing the issue per its acceptance criteria.

Closes #155
Closes #156
Closes #140

## Test plan
- [x] `cd backend && npx vitest run` — 63 passed (15 in `webhook.router.test.ts` after the validation rewrite)
- [x] `cd frontend && npx vitest run` — 12 passed
- [x] `cd backend && npx tsc --noEmit` — no errors in changed files (pre-existing errors in `market/market.service.ts` and `webhooks/webhook.service.test.ts` are unrelated)
- [x] `cd frontend && npx tsc --noEmit` — no errors in changed files (pre-existing errors in `DashboardPage`, `LandingPage`, `SellPage.test.tsx` are unrelated)
- [ ] Manual: with `VITE_API_URL=https://api.example.com` set, network tab shows requests going to `https://api.example.com/api/datasets`; without it, requests go to relative `/api/datasets`
- [ ] Manual: POST `/api/webhooks` with `events: ["nope"]` returns 400 with `error: "Invalid events: nope"`
- [ ] Manual: POST `/api/backups/restore` with `filename: "../etc/passwd"` returns 400 with the path-traversal message