### PR TITLE
fix(api): timeout all client calls (default 30s, agent 120s)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -115,28 +115,41 @@ export interface QueryResult {
   };
 }
 
-async function request<T>(url: string, options?: RequestInit): Promise<T> {
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+export const AGENT_REQUEST_TIMEOUT_MS = 120_000;
+
+interface RequestOptions extends RequestInit {
+  /** Per-call override of the abort timeout, in milliseconds. */
+  timeoutMs?: number;
+}
+
+async function fetchWithTimeout(url: string, options?: RequestOptions): Promise<Response> {
+  const { timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, ...init } = options ?? {};
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(url, {
+    return await fetch(url, {
       headers: { 'Content-Type': 'application/json' },
       signal: controller.signal,
-      ...options,
+      ...init,
     });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: 'Network error' }));
-      throw new Error(err.error || `HTTP ${res.status}`);
-    }
-    return res.json();
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
       throw new Error('Request timed out — please try again');
     }
     throw err;
   } finally {
-    clearTimeout(timeout);
+    clearTimeout(timer);
   }
+}
+
+async function request<T>(url: string, options?: RequestOptions): Promise<T> {
+  const res = await fetchWithTimeout(url, options);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Network error' }));
+    throw new Error(err.error || `HTTP ${res.status}`);
+  }
+  return res.json();
 }
 
 export const api = {
@@ -178,7 +191,7 @@ export const api = {
   },
 
   initiateQuery: (id: string) =>
-    fetch(`${BASE}/query/${id}`, { method: 'POST' }).then((r) => r.json()),
+    fetchWithTimeout(`${BASE}/query/${id}`, { method: 'POST' }).then((r) => r.json()),
 
   verifyPayment: (id: string, txHash: string, buyerQuestion?: string) =>
     request<QueryResult>(`${BASE}/verify/${id}`, {
@@ -199,12 +212,14 @@ export const api = {
     request<AgentJob>(`${BASE}/agent/research/demo`, {
       method: 'POST',
       body: JSON.stringify({ query }),
+      timeoutMs: AGENT_REQUEST_TIMEOUT_MS,
     }),
 
   agentResearch: (query: string, txHash: string) =>
     request<AgentJob>(`${BASE}/agent/research`, {
       method: 'POST',
       body: JSON.stringify({ query, txHash }),
+      timeoutMs: AGENT_REQUEST_TIMEOUT_MS,
     }),
 
   createDataset: (payload: {


### PR DESCRIPTION
## Summary

The shared `request<T>()` helper in `frontend/src/lib/api.ts` already wrapped its fetches with a 30s `AbortController`, but `initiateQuery` used raw `fetch().then(r => r.json())` with no timeout — so the QueryModal's 402-payment-required call could hang indefinitely on a slow or unresponsive backend.

**Refactor**: extract the timeout/abort plumbing into `fetchWithTimeout` so both the JSON-parsing `request` helper and the raw `initiateQuery` call share the same cancellation logic. The 402 response shape is preserved for `initiateQuery` (so `QueryModal` can still read `res.payment`).

**Per-call override**: `request` now accepts an optional `timeoutMs`. Defaults are exported as constants:
- `DEFAULT_REQUEST_TIMEOUT_MS = 30_000`
- `AGENT_REQUEST_TIMEOUT_MS = 120_000`

**Agent endpoints**: `agentResearch` and `agentDemo` are bumped to 120s because AI synthesis routinely exceeds 30s, and timing those out forces the user to retry (and re-pay).

Closes #149

## Test plan
- [x] `cd frontend && npx vitest run` — 12 passed (QueryModal tests still green; the modal awaits the 402 body unchanged)
- [x] `cd frontend && npx tsc --noEmit` — no errors in `lib/api.ts` (pre-existing errors in `DashboardPage`, `LandingPage`, `SellPage.test.tsx` are unrelated)
- [ ] Manual: throttle the network in devtools, open a dataset modal — after 30s the 402 fetch aborts and surfaces "Request timed out — please try again" instead of hanging forever
- [ ] Manual: trigger an agent research call against a slow upstream — the 120s window holds and the call only times out on truly stuck upstreams