### PR TITLE
chore(tooling): configure Dependabot for automated dependency updates…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,133 @@
+version: 2
+
+updates:
+  # Root workspace (husky, lint-staged, concurrently, eslint, prettier, etc.)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "globals"
+      prettier:
+        patterns:
+          - "prettier*"
+      husky-lint-staged:
+        patterns:
+          - "husky"
+          - "lint-staged"
+
+  # Backend workspace
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+      - "backend"
+    commit-message:
+      prefix: "chore(deps/backend)"
+    groups:
+      stellar:
+        patterns:
+          - "@stellar/*"
+      anthropic:
+        patterns:
+          - "@anthropic-ai/*"
+      types:
+        patterns:
+          - "@types/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "supertest"
+
+  # Frontend workspace
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+      - "frontend"
+    commit-message:
+      prefix: "chore(deps/frontend)"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-*"
+          - "@types/react*"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+
+  # Stellar smart contracts (Rust/Cargo)
+  - package-ecosystem: "cargo"
+    directory: "/contracts/hazina-escrow"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "cargo"
+      - "contracts"
+    commit-message:
+      prefix: "chore(deps/contracts)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps/actions)"


### PR DESCRIPTION
… (#74)

Adds .github/dependabot.yml covering all five ecosystems in the repo:
- npm root (eslint, prettier, husky/lint-staged grouped)
- npm backend (stellar, anthropic, types, testing grouped)
- npm frontend (react, tanstack, storybook, vite, testing grouped)
- cargo (contracts/hazina-escrow)
- github-actions

All schedules run weekly on Monday at 09:00 UTC with appropriate labels and conventional-commit prefixes per workspace.

## Summary

<!-- 2-5 sentences on what changed and why. -->

## Related Issue

Closes #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Tests only
- [ ] Documentation
- [ ] CI / tooling / infrastructure

## What Changed

<!-- Call out the key implementation changes, grouped by area if useful. -->

- 

## Testing

<!-- List exactly what you ran and any manual verification a reviewer should repeat. -->

### Automated

- [ ] `cd backend && npm test`
- [ ] `cd frontend && npm test`
- [ ] `cd backend && npm run build`
- [ ] `cd frontend && npm run build`
- [ ] `cd contracts/hazina-escrow && cargo test`
- [ ] Not applicable

### Manual

1. 
2. 
3. 

Demo mode reminder: marketplace and agent flows can be exercised without a funded Stellar wallet where demo endpoints are available.

## Risk & Rollout Notes

<!-- Note migrations, env changes, API contract changes, data changes, or rollback concerns. -->

- User-facing risk:
- Operational risk:
- Rollback plan:

## Screenshots / Recordings

<!-- Required for visual changes when practical. Add before/after images or a short video. -->

## Checklist

- [ ] I verified the change against the relevant parts of the app
- [ ] I updated or added tests where the behavior changed, or explained why tests were not needed
- [ ] I updated docs, comments, examples, or API references if needed
- [ ] I did not commit secrets, private keys, or production-only values
- [ ] I used existing logging/error-handling patterns instead of leaving debug-only output behind
- [ ] I reviewed the diff for accidental changes before requesting review

Closes #74 