### PR TITLE
feat(backend): implement circuit breaker pattern for external API cal…

### DIFF
--- a/backend/src/ai/claude.service.ts
+++ b/backend/src/ai/claude.service.ts
@@ -1,5 +1,11 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { sanitizeUserText } from '../common/sanitize';
+import { getCircuitBreaker } from '../common/circuit-breaker';
+
+const claudeBreaker = getCircuitBreaker('anthropic-claude', {
+  failureThreshold: 3,
+  resetTimeoutMs: 30_000, // 30 s — Claude outages tend to be brief
+});
 
 export function stripMarkdownFence(text: string): string {
   return text
@@ -44,7 +50,7 @@ export function parseClaudeSummaryResponse(
 
 export async function generateDataSummary(
   data: Record<string, unknown>,
-  buyerQuestion?: string
+  buyerQuestion?: string,
 ): Promise<{ summary: string; answer?: string }> {
   const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
   const question = buyerQuestion ? sanitizeUserText(buyerQuestion) : undefined;
@@ -71,16 +77,18 @@ ${JSON.stringify(data, null, 2)}`
 Data:
 ${JSON.stringify(data, null, 2)}`;
 
-  const response = await client.messages.create({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 800,
-    system: systemPrompt,
-    messages: [{ role: 'user', content: prompt }],
-  });
+  const response = await claudeBreaker.execute(() =>
+    client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 800,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  );
 
   const fullText = response.content
-    .filter((b) => b.type === 'text')
-    .map((b) => (b as { type: 'text'; text: string }).text)
+    .filter(b => b.type === 'text')
+    .map(b => (b as { type: 'text'; text: string }).text)
     .join('');
 
   return parseClaudeSummaryResponse(fullText, Boolean(question));

--- a/backend/src/common/__tests__/circuit-breaker.test.ts
+++ b/backend/src/common/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CircuitBreaker, CircuitBreakerOpenError, getCircuitBreaker } from '../circuit-breaker';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const ok =
+  <T>(value: T) =>
+  () =>
+    Promise.resolve(value);
+const fail =
+  (msg = 'boom') =>
+  () =>
+    Promise.reject(new Error(msg));
+
+function makeBreaker(opts?: ConstructorParameters<typeof CircuitBreaker>[1]) {
+  // Use a unique name per test to avoid shared-registry bleed
+  return new CircuitBreaker(`test-${Math.random()}`, opts);
+}
+
+// ── CLOSED state ─────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — CLOSED state', () => {
+  it('starts CLOSED', () => {
+    expect(makeBreaker().getState()).toBe('CLOSED');
+  });
+
+  it('passes through a successful call', async () => {
+    const cb = makeBreaker();
+    await expect(cb.execute(ok(42))).resolves.toBe(42);
+  });
+
+  it('re-throws errors without opening below the threshold', async () => {
+    const cb = makeBreaker({ failureThreshold: 3 });
+    await expect(cb.execute(fail())).rejects.toThrow('boom');
+    await expect(cb.execute(fail())).rejects.toThrow('boom');
+    expect(cb.getState()).toBe('CLOSED');
+  });
+
+  it('opens when failures reach the threshold', async () => {
+    const cb = makeBreaker({ failureThreshold: 2 });
+    await cb.execute(fail()).catch(() => {});
+    await cb.execute(fail()).catch(() => {});
+    expect(cb.getState()).toBe('OPEN');
+  });
+
+  it('resets the failure count after a success', async () => {
+    const cb = makeBreaker({ failureThreshold: 3 });
+    await cb.execute(fail()).catch(() => {});
+    await cb.execute(fail()).catch(() => {});
+    await cb.execute(ok('good')); // resets counter
+    await cb.execute(fail()).catch(() => {});
+    // Only 1 failure after reset — should still be CLOSED
+    expect(cb.getState()).toBe('CLOSED');
+  });
+});
+
+// ── OPEN state ───────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — OPEN state', () => {
+  it('throws CircuitBreakerOpenError without calling fn', async () => {
+    const cb = makeBreaker({ failureThreshold: 1 });
+    await cb.execute(fail()).catch(() => {});
+    expect(cb.getState()).toBe('OPEN');
+
+    const spy = vi.fn(ok('should-not-run'));
+    await expect(cb.execute(spy)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ── HALF_OPEN state ───────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — HALF_OPEN state', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('transitions to HALF_OPEN after resetTimeoutMs', async () => {
+    const cb = makeBreaker({ failureThreshold: 1, resetTimeoutMs: 1_000 });
+    await cb.execute(fail()).catch(() => {});
+    expect(cb.getState()).toBe('OPEN');
+
+    vi.advanceTimersByTime(1_001);
+    // A call is needed to trigger the internal check
+    await cb.execute(ok('probe')).catch(() => {});
+    // Successful probe closes it
+    expect(cb.getState()).toBe('CLOSED');
+  });
+
+  it('closes the circuit when the probe succeeds', async () => {
+    const cb = makeBreaker({ failureThreshold: 1, resetTimeoutMs: 500 });
+    await cb.execute(fail()).catch(() => {});
+    vi.advanceTimersByTime(600);
+    await cb.execute(ok('recovered'));
+    expect(cb.getState()).toBe('CLOSED');
+  });
+
+  it('re-opens the circuit when the probe fails', async () => {
+    const cb = makeBreaker({ failureThreshold: 1, resetTimeoutMs: 500 });
+    await cb.execute(fail()).catch(() => {});
+    vi.advanceTimersByTime(600);
+    await cb.execute(fail()).catch(() => {});
+    expect(cb.getState()).toBe('OPEN');
+  });
+});
+
+// ── Manual reset ─────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — reset()', () => {
+  it('restores CLOSED state from OPEN', async () => {
+    const cb = makeBreaker({ failureThreshold: 1 });
+    await cb.execute(fail()).catch(() => {});
+    expect(cb.getState()).toBe('OPEN');
+    cb.reset();
+    expect(cb.getState()).toBe('CLOSED');
+  });
+
+  it('allows calls to succeed after reset', async () => {
+    const cb = makeBreaker({ failureThreshold: 1 });
+    await cb.execute(fail()).catch(() => {});
+    cb.reset();
+    await expect(cb.execute(ok('back'))).resolves.toBe('back');
+  });
+});
+
+// ── onStateChange callback ────────────────────────────────────────────────────
+
+describe('CircuitBreaker — onStateChange', () => {
+  it('fires on CLOSED → OPEN transition', async () => {
+    const spy = vi.fn();
+    const cb = makeBreaker({ failureThreshold: 1, onStateChange: spy });
+    await cb.execute(fail()).catch(() => {});
+    expect(spy).toHaveBeenCalledWith(expect.any(String), 'CLOSED', 'OPEN');
+  });
+});
+
+// ── Registry ─────────────────────────────────────────────────────────────────
+
+describe('getCircuitBreaker registry', () => {
+  it('returns the same instance for the same name', () => {
+    const a = getCircuitBreaker('shared-name-test');
+    const b = getCircuitBreaker('shared-name-test');
+    expect(a).toBe(b);
+  });
+
+  it('returns different instances for different names', () => {
+    const a = getCircuitBreaker('svc-a');
+    const b = getCircuitBreaker('svc-b');
+    expect(a).not.toBe(b);
+  });
+});

--- a/backend/src/common/circuit-breaker.ts
+++ b/backend/src/common/circuit-breaker.ts
@@ -1,0 +1,172 @@
+/**
+ * Circuit Breaker pattern for external API calls.
+ *
+ * States:
+ *   CLOSED    — Normal operation; failures are counted.
+ *   OPEN      — Service is assumed down; calls fail-fast without hitting the API.
+ *   HALF_OPEN — One probe request is allowed through to test recovery.
+ *
+ * Transitions:
+ *   CLOSED  → OPEN      : failureCount reaches failureThreshold
+ *   OPEN    → HALF_OPEN : resetTimeoutMs elapses
+ *   HALF_OPEN → CLOSED  : probe request succeeds
+ *   HALF_OPEN → OPEN    : probe request fails
+ */
+
+export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+export interface CircuitBreakerOptions {
+  /** Number of consecutive failures before opening the circuit. Default: 5 */
+  failureThreshold?: number;
+  /** Milliseconds to wait in OPEN state before attempting a probe. Default: 60_000 */
+  resetTimeoutMs?: number;
+  /** Optional callback invoked on state transitions (useful for metrics/logging). */
+  onStateChange?: (name: string, from: CircuitState, to: CircuitState) => void;
+}
+
+export class CircuitBreakerOpenError extends Error {
+  constructor(name: string) {
+    super(`Circuit breaker "${name}" is OPEN — downstream service unavailable`);
+    this.name = 'CircuitBreakerOpenError';
+  }
+}
+
+export class CircuitBreaker {
+  private state: CircuitState = 'CLOSED';
+  private failureCount = 0;
+  private lastFailureTime: number | null = null;
+  private probeInFlight = false;
+
+  readonly name: string;
+  private readonly failureThreshold: number;
+  private readonly resetTimeoutMs: number;
+  private readonly onStateChange?: (name: string, from: CircuitState, to: CircuitState) => void;
+
+  constructor(name: string, options: CircuitBreakerOptions = {}) {
+    this.name = name;
+    this.failureThreshold = options.failureThreshold ?? 5;
+    this.resetTimeoutMs = options.resetTimeoutMs ?? 60_000;
+    this.onStateChange = options.onStateChange;
+  }
+
+  /** Current circuit state (read-only). */
+  getState(): CircuitState {
+    return this.state;
+  }
+
+  /** Stats snapshot — useful for health-check endpoints. */
+  getStats() {
+    return {
+      name: this.name,
+      state: this.state,
+      failureCount: this.failureCount,
+      failureThreshold: this.failureThreshold,
+      resetTimeoutMs: this.resetTimeoutMs,
+      lastFailureTime: this.lastFailureTime,
+    };
+  }
+
+  /**
+   * Execute `fn` through the circuit breaker.
+   *
+   * - CLOSED:    runs normally; failure increments counter.
+   * - OPEN:      throws CircuitBreakerOpenError immediately (no network call).
+   * - HALF_OPEN: allows one probe; success → CLOSED, failure → OPEN.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    this.tryTransitionToHalfOpen();
+
+    if (this.state === 'OPEN') {
+      throw new CircuitBreakerOpenError(this.name);
+    }
+
+    if (this.state === 'HALF_OPEN') {
+      if (this.probeInFlight) {
+        // Another concurrent call during half-open — fail fast.
+        throw new CircuitBreakerOpenError(this.name);
+      }
+      this.probeInFlight = true;
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      this.onFailure();
+      throw err;
+    } finally {
+      this.probeInFlight = false;
+    }
+  }
+
+  /** Manually reset the circuit to CLOSED (e.g. after a deploy / config fix). */
+  reset(): void {
+    this.transition('CLOSED');
+    this.failureCount = 0;
+    this.lastFailureTime = null;
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  private tryTransitionToHalfOpen(): void {
+    if (
+      this.state === 'OPEN' &&
+      this.lastFailureTime !== null &&
+      Date.now() - this.lastFailureTime >= this.resetTimeoutMs
+    ) {
+      this.transition('HALF_OPEN');
+    }
+  }
+
+  private onSuccess(): void {
+    if (this.state === 'HALF_OPEN') {
+      this.transition('CLOSED');
+    }
+    this.failureCount = 0;
+  }
+
+  private onFailure(): void {
+    this.failureCount += 1;
+    this.lastFailureTime = Date.now();
+
+    if (this.state === 'HALF_OPEN' || this.failureCount >= this.failureThreshold) {
+      this.transition('OPEN');
+    }
+  }
+
+  private transition(next: CircuitState): void {
+    if (this.state === next) {
+      return;
+    }
+    const prev = this.state;
+    this.state = next;
+    console.warn(`[CircuitBreaker] "${this.name}" ${prev} → ${next}`);
+    this.onStateChange?.(this.name, prev, next);
+  }
+}
+
+// ── Singleton registry ───────────────────────────────────────────────────────
+// One breaker per named external service, shared across the process lifetime.
+
+const registry = new Map<string, CircuitBreaker>();
+
+/**
+ * Returns (or creates) a named CircuitBreaker instance.
+ * Options are only applied on first creation.
+ */
+export function getCircuitBreaker(name: string, options?: CircuitBreakerOptions): CircuitBreaker {
+  if (!registry.has(name)) {
+    registry.set(name, new CircuitBreaker(name, options));
+  }
+  const breaker = registry.get(name);
+  if (!breaker) {
+    throw new Error(`CircuitBreaker "${name}" not found in registry after creation`);
+  }
+  return breaker;
+}
+
+/** Returns stats for every registered circuit breaker (for health endpoints). */
+export function getAllCircuitBreakerStats() {
+  return Array.from(registry.values()).map(cb => cb.getStats());
+}

--- a/backend/src/common/health.ts
+++ b/backend/src/common/health.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { getAllCircuitBreakerStats } from './circuit-breaker';
 
 interface HealthStatus {
   status: 'healthy' | 'degraded' | 'unhealthy';
@@ -11,6 +12,7 @@ interface HealthStatus {
       responseTime?: number;
     };
   };
+  circuitBreakers: ReturnType<typeof getAllCircuitBreakerStats>;
 }
 
 export async function checkHealth(): Promise<HealthStatus> {
@@ -20,7 +22,7 @@ export async function checkHealth(): Promise<HealthStatus> {
   };
 
   const hasError = Object.values(checks).some(
-    (check) => check.status === 'error' || check.status === 'unavailable'
+    check => check.status === 'error' || check.status === 'unavailable',
   );
 
   const status: HealthStatus['status'] = hasError ? 'degraded' : 'healthy';
@@ -30,6 +32,7 @@ export async function checkHealth(): Promise<HealthStatus> {
     timestamp,
     service: 'Hazina Escrow API',
     checks,
+    circuitBreakers: getAllCircuitBreakerStats(),
   };
 }
 

--- a/backend/src/market/market.service.ts
+++ b/backend/src/market/market.service.ts
@@ -1,62 +1,94 @@
+import { getCircuitBreaker, CircuitBreakerOpenError } from '../common/circuit-breaker';
+
+const coingeckoBreaker = getCircuitBreaker('coingecko', {
+  failureThreshold: 4,
+  resetTimeoutMs: 120_000, // 2 min — CoinGecko rate-limits aggressively
+});
+
 /**
  * MarketService handles external market data from CoinGecko
  * and provides deep links for manual data verification on Stellar.Expert.
  */
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class MarketService {
-    private static readonly COINGECKO_BASE = "https://api.coingecko.com/api/v3";
+  private static readonly COINGECKO_BASE = 'https://api.coingecko.com/api/v3';
 
   /**
-     * Fetches the current USD price for a given asset from CoinGecko.
-     * Includes error handling and optional API key support.
-     */
-  static async getPrice(coinId: string = "stellar"): Promise<number | null> {
-        try {
-                const apiKey = process.env.COINGECKO_API_KEY;
-                const headers = apiKey ? { "x-cg-demo-api-key": apiKey } : {};
+   * Fetches the current USD price for a given asset from CoinGecko.
+   * Returns null when the circuit is open or the request fails.
+   */
+  static async getPrice(coinId: string = 'stellar'): Promise<number | null> {
+    try {
+      const apiKey = process.env.COINGECKO_API_KEY;
+      const headers: Record<string, string> = apiKey ? { 'x-cg-demo-api-key': apiKey } : {};
 
-          const response = await fetch(
-                    `${this.COINGECKO_BASE}/simple/price?ids=${coinId}&vs_currencies=usd`,
-            { headers }
-                  );
-                const data = await response.json() as any;
-                return data[coinId]?.usd || null;
-        } catch (error) {
-                console.error("MarketService Error:", error);
-                return null;
-        }
+      const data = await coingeckoBreaker.execute(async () => {
+        const response = await fetch(
+          `${this.COINGECKO_BASE}/simple/price?ids=${coinId}&vs_currencies=usd`,
+          { headers },
+        );
+        return response.json() as Promise<Record<string, { usd?: number }>>;
+      });
+
+      return data[coinId]?.usd ?? null;
+    } catch (error) {
+      if (error instanceof CircuitBreakerOpenError) {
+        console.warn(`[MarketService] ${error.message} — returning null for getPrice`);
+      } else {
+        console.error('[MarketService] getPrice error:', error);
+      }
+      return null;
+    }
   }
 
   /**
-     * Generates a clickable link to Stellar.Expert for a specific asset.
-     */
+   * Generates a clickable link to Stellar.Expert for a specific asset.
+   */
   static getExplorerLink(assetCode: string, issuer?: string): string {
-        const code = assetCode.toUpperCase();
-        if (code === "XLM") {
-                return "https://stellar.expert/explorer/public/asset/XLM";
-        }
-        return `https://stellar.expert/explorer/public/asset/${code}${issuer ? "-" + issuer : ""}`;
+    const code = assetCode.toUpperCase();
+    if (code === 'XLM') {
+      return 'https://stellar.expert/explorer/public/asset/XLM';
+    }
+    return `https://stellar.expert/explorer/public/asset/${code}${issuer ? '-' + issuer : ''}`;
   }
 
   /**
-     * Fetches market metrics (volume, change) for broader synthesis correlation.
-     */
-  static async getMarketMetrics(coinId: string = "stellar"): Promise<any> {
-        try {
-                const apiKey = process.env.COINGECKO_API_KEY;
-                const headers = apiKey ? { "x-cg-demo-api-key": apiKey } : {};
+   * Fetches market metrics (volume, change) for broader synthesis correlation.
+   * Returns null when the circuit is open or the request fails.
+   */
+  static async getMarketMetrics(coinId: string = 'stellar'): Promise<{
+    price: number | null;
+    volume24h: number | null;
+    change24h: number | null;
+  } | null> {
+    try {
+      const apiKey = process.env.COINGECKO_API_KEY;
+      const headers: Record<string, string> = apiKey ? { 'x-cg-demo-api-key': apiKey } : {};
 
-          const response = await fetch(
-                    `${this.COINGECKO_BASE}/coins/${coinId}?localization=false&tickers=false&market_data=true`,
-            { headers }
-                  );
-                const data = await response.json() as any;
-                return {
-                          price: data.market_data?.current_price?.usd,
-                          volume24h: data.market_data?.total_volume?.usd,
-                          change24h: data.market_data?.price_change_percentage_24h
-                };
-        } catch {
-                return null;
-        }
+      const data = await coingeckoBreaker.execute(async () => {
+        const response = await fetch(
+          `${this.COINGECKO_BASE}/coins/${coinId}?localization=false&tickers=false&market_data=true`,
+          { headers },
+        );
+        return response.json() as Promise<{
+          market_data?: {
+            current_price?: { usd?: number };
+            total_volume?: { usd?: number };
+            price_change_percentage_24h?: number;
+          };
+        }>;
+      });
+
+      return {
+        price: data.market_data?.current_price?.usd ?? null,
+        volume24h: data.market_data?.total_volume?.usd ?? null,
+        change24h: data.market_data?.price_change_percentage_24h ?? null,
+      };
+    } catch (error) {
+      if (error instanceof CircuitBreakerOpenError) {
+        console.warn(`[MarketService] ${error.message} — returning null for getMarketMetrics`);
+      }
+      return null;
+    }
   }
 }

--- a/backend/src/payments/stellar.service.ts
+++ b/backend/src/payments/stellar.service.ts
@@ -1,6 +1,12 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { getCircuitBreaker } from '../common/circuit-breaker';
 
 const server = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org');
+
+const stellarBreaker = getCircuitBreaker('stellar-horizon', {
+  failureThreshold: 5,
+  resetTimeoutMs: 60_000, // 60 s
+});
 
 interface VerifyParams {
   txHash: string;
@@ -19,14 +25,16 @@ export async function verifyStellarPayment(params: VerifyParams): Promise<Verify
   const { txHash, expectedAmount, destinationAddress } = params;
 
   try {
-    const tx = await server.transactions().transaction(txHash).call();
-
-    // Load operations for this transaction
-    const ops = await server.operations().forTransaction(txHash).call();
+    const [tx, ops] = await stellarBreaker.execute(() =>
+      Promise.all([
+        server.transactions().transaction(txHash).call(),
+        server.operations().forTransaction(txHash).call(),
+      ]),
+    );
     const paymentOps = ops.records.filter(
-      (op) =>
+      op =>
         op.type === 'payment' &&
-        (op as StellarSdk.Horizon.ServerApi.PaymentOperationRecord).to === destinationAddress
+        (op as StellarSdk.Horizon.ServerApi.PaymentOperationRecord).to === destinationAddress,
     );
 
     if (paymentOps.length === 0) {
@@ -35,16 +43,18 @@ export async function verifyStellarPayment(params: VerifyParams): Promise<Verify
 
     // Find USDC payment — must match both asset code and issuer to prevent XLM/fake-USDC substitution
     const expectedIssuer = process.env.USDC_ISSUER;
-    const usdcOps = paymentOps.filter((op) => {
+    const usdcOps = paymentOps.filter(op => {
       const payOp = op as StellarSdk.Horizon.ServerApi.PaymentOperationRecord;
       return (
-        payOp.asset_code === 'USDC' &&
-        (!expectedIssuer || payOp.asset_issuer === expectedIssuer)
+        payOp.asset_code === 'USDC' && (!expectedIssuer || payOp.asset_issuer === expectedIssuer)
       );
     });
 
     if (usdcOps.length === 0) {
-      return { valid: false, reason: 'No USDC payment found — ensure you sent USDC on Stellar testnet' };
+      return {
+        valid: false,
+        reason: 'No USDC payment found — ensure you sent USDC on Stellar testnet',
+      };
     }
 
     const payOp = usdcOps[0] as StellarSdk.Horizon.ServerApi.PaymentOperationRecord;

--- a/backend/src/webhooks/webhook.service.ts
+++ b/backend/src/webhooks/webhook.service.ts
@@ -1,12 +1,20 @@
-import crypto from "crypto";
-import https from "https";
-import http from "http";
-import { URL } from "url";
-import {
-  WebhookEvent,
-  WebhookSubscription,
-  getWebhooksForSeller,
-} from "../common/storage";
+import crypto from 'crypto';
+import https from 'https';
+import http from 'http';
+import { URL } from 'url';
+import { WebhookEvent, WebhookSubscription, getWebhooksForSeller } from '../common/storage';
+import { getCircuitBreaker, CircuitBreakerOpenError } from '../common/circuit-breaker';
+
+/**
+ * Each webhook subscriber gets its own circuit breaker keyed by subscription ID.
+ * This isolates misbehaving endpoints from healthy ones.
+ */
+function getBreakerForSubscription(subscriptionId: string) {
+  return getCircuitBreaker(`webhook:${subscriptionId}`, {
+    failureThreshold: 3,
+    resetTimeoutMs: 300_000, // 5 min — give slow consumer endpoints time to recover
+  });
+}
 
 export interface WebhookPayload {
   event: WebhookEvent;
@@ -21,7 +29,7 @@ const RETRY_DELAYS_MS = [1000, 2000, 4000];
  * Generates HMAC-SHA256 signature for webhook payload.
  */
 export function signPayload(body: string, secret: string): string {
-  return crypto.createHmac("sha256", secret).update(body).digest("hex");
+  return crypto.createHmac('sha256', secret).update(body).digest('hex');
 }
 
 /**
@@ -43,39 +51,50 @@ export async function dispatchWebhook(
 
   const url = new URL(subscription.url);
   const options: http.RequestOptions = {
-    method: "POST",
+    method: 'POST',
     hostname: url.hostname,
-    port: url.port || (url.protocol === "https:" ? 443 : 80),
+    port: url.port || (url.protocol === 'https:' ? 443 : 80),
     path: url.pathname + url.search,
     headers: {
-      "Content-Type": "application/json",
-      "X-Webhook-Signature": signature,
-      "X-Webhook-Event": event,
-      "X-Webhook-Id": subscription.id,
-      "Content-Length": Buffer.byteLength(bodyString),
+      'Content-Type': 'application/json',
+      'X-Webhook-Signature': signature,
+      'X-Webhook-Event': event,
+      'X-Webhook-Id': subscription.id,
+      'Content-Length': Buffer.byteLength(bodyString),
     },
     timeout: 10000,
   };
 
-  const client = url.protocol === "https:" ? https : http;
+  const client = url.protocol === 'https:' ? https : http;
+
+  const breaker = getBreakerForSubscription(subscription.id);
+
+  // Fail-fast when this subscriber's circuit is open
+  if (breaker.getState() === 'OPEN') {
+    console.warn(
+      `[Webhook] Circuit OPEN for ${subscription.url} (${subscription.id}) — skipping dispatch`,
+    );
+    return;
+  }
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const statusCode = await sendRequest(client, options, bodyString);
+      const statusCode = await breaker.execute(() => sendRequest(client, options, bodyString));
       if (statusCode >= 200 && statusCode < 300) {
-        console.log(
-          `[Webhook] Dispatched ${event} to ${subscription.url} (${subscription.id})`,
+        console.log(`[Webhook] Dispatched ${event} to ${subscription.url} (${subscription.id})`);
+        return;
+      }
+      // Treat non-2xx as a failure so the breaker counts it
+      throw new Error(`HTTP ${statusCode}`);
+    } catch (err) {
+      if (err instanceof CircuitBreakerOpenError) {
+        console.warn(
+          `[Webhook] Circuit opened for ${subscription.url} (${subscription.id}) — aborting retries`,
         );
         return;
       }
-      console.warn(
-        `[Webhook] Attempt ${attempt + 1} failed with status ${statusCode} for ${subscription.url}`,
-      );
-    } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[Webhook] Attempt ${attempt + 1} error: ${message} for ${subscription.url}`,
-      );
+      console.warn(`[Webhook] Attempt ${attempt + 1} error: ${message} for ${subscription.url}`);
     }
 
     if (attempt < MAX_RETRIES - 1) {
@@ -99,14 +118,14 @@ export async function notifySeller(
 ): Promise<void> {
   const webhooks = getWebhooksForSeller(sellerWallet);
   const matching = webhooks.filter(
-    (w) => w.active && (w.events.length === 0 || w.events.includes(event)),
+    w => w.active && (w.events.length === 0 || w.events.includes(event)),
   );
 
   if (matching.length === 0) return;
 
   // Fire-and-forget in parallel
   await Promise.all(
-    matching.map((sub) =>
+    matching.map(sub =>
       dispatchWebhook(sub, event, payload).catch(() => {
         // Already logged inside dispatchWebhook
       }),
@@ -124,16 +143,16 @@ function sendRequest(
   body: string,
 ): Promise<number> {
   return new Promise((resolve, reject) => {
-    const req = client.request(options, (res) => {
+    const req = client.request(options, res => {
       // Drain response to free socket
-      res.on("data", () => {});
-      res.on("end", () => resolve(res.statusCode ?? 0));
+      res.on('data', () => {});
+      res.on('end', () => resolve(res.statusCode ?? 0));
     });
 
-    req.on("error", reject);
-    req.on("timeout", () => {
+    req.on('error', reject);
+    req.on('timeout', () => {
       req.destroy();
-      reject(new Error("Request timeout"));
+      reject(new Error('Request timeout'));
     });
 
     req.write(body);
@@ -142,5 +161,5 @@ function sendRequest(
 }
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "typescript-eslint": "^8.18.0"
   },
   "lint-staged": {
-    "backend/src/**/*.ts": [
-      "prettier --write",
-      "npm run lint --prefix backend -- --max-warnings=0"
+    "backend/src/**/*.{ts,tsx}": [
+      "npx prettier --write",
+      "npx eslint --max-warnings=0"
     ],
     "frontend/src/**/*.{ts,tsx}": [
-      "prettier --write",
-      "npm run lint --prefix frontend -- --max-warnings=0"
+      "npx prettier --write",
+      "npx eslint --max-warnings=0"
     ]
   }
 }


### PR DESCRIPTION
…ls (#57)

Adds a reusable CircuitBreaker class (CLOSED → OPEN → HALF_OPEN state machine) with a singleton registry, then wraps every external service:

- anthropic-claude  (failureThreshold=3, resetTimeout=30s)
- stellar-horizon   (failureThreshold=5, resetTimeout=60s)
- coingecko         (failureThreshold=4, resetTimeout=120s)
- webhook:<id>      (per-subscriber, failureThreshold=3, resetTimeout=5min)

Health endpoint now includes circuit breaker stats for all registered breakers. 14 unit tests cover all state transitions, error propagation, manual reset, and the singleton registry.

Also fixes lint-staged config to use root ESLint 9 flat config instead of deprecated workspace --ext flag.

## Summary

<!-- 2-5 sentences on what changed and why. -->

## Related Issue

Closes #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Tests only
- [ ] Documentation
- [ ] CI / tooling / infrastructure

## What Changed

<!-- Call out the key implementation changes, grouped by area if useful. -->

- 

## Testing

<!-- List exactly what you ran and any manual verification a reviewer should repeat. -->

### Automated

- [ ] `cd backend && npm test`
- [ ] `cd frontend && npm test`
- [ ] `cd backend && npm run build`
- [ ] `cd frontend && npm run build`
- [ ] `cd contracts/hazina-escrow && cargo test`
- [ ] Not applicable

### Manual

1. 
2. 
3. 

Demo mode reminder: marketplace and agent flows can be exercised without a funded Stellar wallet where demo endpoints are available.

## Risk & Rollout Notes

<!-- Note migrations, env changes, API contract changes, data changes, or rollback concerns. -->

- User-facing risk:
- Operational risk:
- Rollback plan:

## Screenshots / Recordings

<!-- Required for visual changes when practical. Add before/after images or a short video. -->

## Checklist

- [ ] I verified the change against the relevant parts of the app
- [ ] I updated or added tests where the behavior changed, or explained why tests were not needed
- [ ] I updated docs, comments, examples, or API references if needed
- [ ] I did not commit secrets, private keys, or production-only values
- [ ] I used existing logging/error-handling patterns instead of leaving debug-only output behind
- [ ] I reviewed the diff for accidental changes before requesting review

Closes #57 