### PR TITLE
feat: wire Soroban escrow contract into payment verification flow (#11)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,10 @@
 PORT=3001
 FRONTEND_URL=http://localhost:5173
 
+# Soroban Escrow Contract
+# Deployed on Stellar testnet — buyers lock USDC here; backend calls release()/refund()
+CONTRACT_ID=CCPG2CSL6WDUA2IFUDHFN5SCJQUTFCLFKMTARALQ5RWGB2RGG345HEEH
+
 # API Authentication
 # Protects seller write operations (POST /api/datasets, webhook management).
 # Generate with: openssl rand -hex 32

--- a/backend/src/agent/agent.wallet.ts
+++ b/backend/src/agent/agent.wallet.ts
@@ -1,6 +1,8 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
 
 const server = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org');
+const SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+const CONTRACT_CALL_TIMEOUT_MS = 30_000;
 
 // Testnet USDC issuer (Circle testnet)
 const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
@@ -58,6 +60,58 @@ export async function sendUsdcPayment(params: SendPaymentParams): Promise<SendPa
     to: params.destinationAddress,
     amount: params.amount,
   };
+}
+
+/**
+ * Invokes a Soroban contract function as admin (AGENT_WALLET_SECRET).
+ * Simulates, assembles auth, signs, submits, and polls for confirmation.
+ * Returns the confirmed transaction hash.
+ */
+export async function callContract(
+  contractId: string,
+  method: string,
+  args: StellarSdk.xdr.ScVal[],
+): Promise<string> {
+  const secret = process.env.AGENT_WALLET_SECRET;
+  if (!secret) throw new Error('AGENT_WALLET_SECRET not configured');
+
+  const keypair = StellarSdk.Keypair.fromSecret(secret);
+  const rpc = new StellarSdk.rpc.Server(SOROBAN_RPC_URL);
+  const contract = new StellarSdk.Contract(contractId);
+
+  const account = await rpc.getAccount(keypair.publicKey());
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: StellarSdk.Networks.TESTNET,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const simResult = await rpc.simulateTransaction(tx);
+  if (!StellarSdk.rpc.Api.isSimulationSuccess(simResult)) {
+    throw new Error(`Contract simulation failed for ${method}: ${JSON.stringify(simResult)}`);
+  }
+
+  const assembled = StellarSdk.rpc.assembleTransaction(tx, simResult).build();
+  assembled.sign(keypair);
+
+  const sendResult = await rpc.sendTransaction(assembled);
+  if (sendResult.status === 'ERROR') {
+    throw new Error(`Contract submit error for ${method}: ${JSON.stringify(sendResult.errorResult)}`);
+  }
+
+  const txHash = sendResult.hash;
+  const deadline = Date.now() + CONTRACT_CALL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const txResult = await rpc.getTransaction(txHash);
+    if (txResult.status === StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS) return txHash;
+    if (txResult.status === StellarSdk.rpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error(`Contract call ${method} failed on-chain`);
+    }
+    await new Promise(r => setTimeout(r, 1_000));
+  }
+  throw new Error(`Contract call ${method} timed out after ${CONTRACT_CALL_TIMEOUT_MS}ms`);
 }
 
 export function getAgentPublicKey(): string | null {

--- a/backend/src/lib/contract.client.ts
+++ b/backend/src/lib/contract.client.ts
@@ -1,0 +1,116 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { callContract } from '../agent/agent.wallet';
+
+const SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+const DEFAULT_CONTRACT_ID = 'CCPG2CSL6WDUA2IFUDHFN5SCJQUTFCLFKMTARALQ5RWGB2RGG345HEEH';
+
+function contractId(): string {
+  return process.env.CONTRACT_ID || DEFAULT_CONTRACT_ID;
+}
+
+export interface EscrowRecord {
+  escrow_id: bigint;
+  dataset_id: string;
+  buyer: string;
+  seller: string;
+  amount: bigint;  // in stroops (7 decimal places: 1 USDC = 10_000_000)
+  released: boolean;
+  refunded: boolean;
+}
+
+/** Convert a USDC float (e.g. 1.5) to Soroban i128 stroops. */
+export function usdcToStroops(usdc: number): bigint {
+  return BigInt(Math.round(usdc * 10_000_000));
+}
+
+/**
+ * Read an escrow record from the contract without signing (simulate-only).
+ * Throws if the escrow does not exist.
+ */
+export async function getEscrow(escrowId: number): Promise<EscrowRecord> {
+  const secret = process.env.AGENT_WALLET_SECRET;
+  if (!secret) throw new Error('AGENT_WALLET_SECRET not configured');
+
+  const keypair = StellarSdk.Keypair.fromSecret(secret);
+  const rpc = new StellarSdk.rpc.Server(SOROBAN_RPC_URL);
+  const contract = new StellarSdk.Contract(contractId());
+
+  const account = await rpc.getAccount(keypair.publicKey());
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: StellarSdk.Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call('get_escrow', StellarSdk.nativeToScVal(BigInt(escrowId), { type: 'u64' })),
+    )
+    .setTimeout(30)
+    .build();
+
+  const simResult = await rpc.simulateTransaction(tx);
+  if (!StellarSdk.rpc.Api.isSimulationSuccess(simResult)) {
+    throw new Error(`get_escrow(${escrowId}) failed: ${JSON.stringify(simResult)}`);
+  }
+
+  const retval = simResult.result?.retval;
+  if (!retval) throw new Error(`get_escrow(${escrowId}) returned no value`);
+
+  const raw = StellarSdk.scValToNative(retval) as Record<string, unknown>;
+  return {
+    escrow_id: BigInt(String(raw.escrow_id)),
+    dataset_id: String(raw.dataset_id),
+    buyer: String(raw.buyer),
+    seller: String(raw.seller),
+    amount: BigInt(String(raw.amount)),
+    released: Boolean(raw.released),
+    refunded: Boolean(raw.refunded),
+  };
+}
+
+/**
+ * Admin calls release(escrowId) — contract pays 95% to seller, 5% to admin.
+ * Returns the confirmed transaction hash.
+ */
+export async function releaseEscrow(escrowId: number): Promise<string> {
+  const adminPublicKey = StellarSdk.Keypair.fromSecret(
+    process.env.AGENT_WALLET_SECRET!,
+  ).publicKey();
+
+  return callContract(contractId(), 'release', [
+    new StellarSdk.Address(adminPublicKey).toScVal(),
+    StellarSdk.nativeToScVal(BigInt(escrowId), { type: 'u64' }),
+  ]);
+}
+
+/**
+ * Admin calls refund(escrowId) — contract returns full amount to buyer.
+ * Returns the confirmed transaction hash.
+ */
+export async function refundEscrow(escrowId: number): Promise<string> {
+  const adminPublicKey = StellarSdk.Keypair.fromSecret(
+    process.env.AGENT_WALLET_SECRET!,
+  ).publicKey();
+
+  return callContract(contractId(), 'refund', [
+    new StellarSdk.Address(adminPublicKey).toScVal(),
+    StellarSdk.nativeToScVal(BigInt(escrowId), { type: 'u64' }),
+  ]);
+}
+
+/**
+ * lockEscrow is called by the buyer's wallet, not the backend.
+ * The buyer invokes lock() directly on the Soroban contract from their own keypair,
+ * then passes the returned escrow_id to POST /api/verify/:id.
+ *
+ * This stub is included so the typed interface is complete for frontend consumers.
+ */
+export async function lockEscrow(_params: {
+  buyerPublicKey: string;
+  sellerPublicKey: string;
+  tokenAddress: string;
+  amountStroops: bigint;
+  datasetId: string;
+}): Promise<never> {
+  throw new Error(
+    'lockEscrow must be signed by the buyer. Call lock() directly from the buyer wallet.',
+  );
+}

--- a/backend/src/payments/payments.router.ts
+++ b/backend/src/payments/payments.router.ts
@@ -8,16 +8,15 @@ import {
   txHashUsed,
 } from "../common/storage";
 import { validateBody } from "../common/validate";
-import { verifyStellarPayment } from "./stellar.service";
 import { generateDataSummary } from "../ai/claude.service";
-import { sendUsdcPayment } from "../agent/agent.wallet";
 import { notifySeller } from "../webhooks/webhook.service";
+import { getEscrow, releaseEscrow, refundEscrow, usdcToStroops } from "../lib/contract.client";
 import { sanitizeUserText } from "../common/sanitize";
 
 export const paymentsRouter = Router();
 
 const verifySchema = z.object({
-  txHash: z.string().trim().min(1, "txHash is required").max(200),
+  escrowId: z.number().int().nonnegative(),
   buyerQuestion: z
     .string()
     .max(500)
@@ -90,10 +89,11 @@ const verifyDemoSchema = z.object({
  *           schema:
  *             type: object
  *             required:
- *               - txHash
+ *               - escrowId
  *             properties:
- *               txHash:
- *                 type: string
+ *               escrowId:
+ *                 type: integer
+ *                 description: The escrow_id returned by lock() on the Soroban contract
  *               buyerQuestion:
  *                 type: string
  *     responses:
@@ -168,33 +168,50 @@ paymentsRouter.post("/query/:id", (req: Request, res: Response) => {
   });
 });
 
-// POST /api/verify/:id — verify payment and release data
+// POST /api/verify/:id — verify on-chain escrow lock and release funds via Soroban contract
 paymentsRouter.post("/verify/:id", validateBody(verifySchema), async (req: Request, res: Response) => {
-  const { txHash, buyerQuestion } = req.body as z.infer<typeof verifySchema>;
+  const { escrowId, buyerQuestion } = req.body as z.infer<typeof verifySchema>;
   const dataset = getDataset(req.params.id);
 
   if (!dataset) return res.status(404).json({ error: "Dataset not found" });
 
-  // Check replay
-  if (txHashUsed(txHash)) {
-    return res.status(400).json({ error: "Transaction hash already used" });
+  const escrowKey = `escrow-${escrowId}`;
+  if (txHashUsed(escrowKey)) {
+    return res.status(400).json({ error: "Escrow already processed" });
   }
 
   try {
-    // Verify on Stellar testnet
-    const verification = await verifyStellarPayment({
-      txHash,
-      expectedAmount: dataset.pricePerQuery,
-      destinationAddress: process.env.ESCROW_WALLET || dataset.sellerWallet,
-    });
-
-    if (!verification.valid) {
-      return res
-        .status(400)
-        .json({ error: verification.reason || "Payment verification failed" });
+    // Verify the lock exists on the Soroban contract
+    let escrow;
+    try {
+      escrow = await getEscrow(escrowId);
+    } catch (err) {
+      return res.status(400).json({
+        error: `Escrow #${escrowId} not found on contract: ${err instanceof Error ? err.message : err}`,
+      });
     }
 
-    // Generate AI summary
+    if (escrow.released) {
+      return res.status(400).json({ error: "Escrow already released" });
+    }
+    if (escrow.refunded) {
+      return res.status(400).json({ error: "Escrow already refunded" });
+    }
+    if (escrow.dataset_id !== dataset.id) {
+      return res.status(400).json({
+        error: `Escrow dataset mismatch: expected ${dataset.id}, got ${escrow.dataset_id}`,
+      });
+    }
+
+    const expectedStroops = usdcToStroops(dataset.pricePerQuery);
+    const tolerance = usdcToStroops(0.001);
+    if (escrow.amount < expectedStroops - tolerance) {
+      return res.status(400).json({
+        error: `Escrow amount too low: expected ${expectedStroops} stroops, got ${escrow.amount}`,
+      });
+    }
+
+    // Generate AI summary — refund and abort if this fails
     let summary = "";
     let answer: string | undefined;
     try {
@@ -202,29 +219,24 @@ paymentsRouter.post("/verify/:id", validateBody(verifySchema), async (req: Reque
       summary = result.summary;
       answer = result.answer;
     } catch (aiErr) {
-      console.warn("AI summary failed, proceeding without:", aiErr);
-      summary =
-        "Data delivered successfully. AI summary temporarily unavailable.";
+      console.error("[Escrow] AI step failed — refunding buyer:", aiErr);
+      try {
+        const refundTxHash = await refundEscrow(escrowId);
+        console.log(`[Escrow] Refunded escrow #${escrowId} → ${refundTxHash}`);
+      } catch (refundErr) {
+        console.error("[Escrow] Refund also failed:", refundErr);
+      }
+      return res.status(500).json({ error: "AI processing failed — escrow refunded" });
     }
 
-    // Forward 95% to seller on-chain
-    let sellerTxHash: string | undefined;
+    // Release funds on-chain: contract pays 95% to seller, 5% to admin
+    let releaseTxHash: string | undefined;
     const sellerAmount = parseFloat((dataset.pricePerQuery * 0.95).toFixed(7));
     try {
-      const payment = await sendUsdcPayment({
-        destinationAddress: dataset.sellerWallet,
-        amount: sellerAmount.toFixed(7),
-        memo: `hazina-${dataset.id.slice(0, 10)}`,
-      });
-      sellerTxHash = payment.txHash;
-      console.log(
-        `[Escrow] Paid seller ${sellerAmount} USDC → ${dataset.sellerWallet} (${sellerTxHash})`,
-      );
-    } catch (payErr) {
-      console.warn(
-        "[Escrow] Seller payment failed (data still delivered):",
-        payErr instanceof Error ? payErr.message : payErr,
-      );
+      releaseTxHash = await releaseEscrow(escrowId);
+      console.log(`[Escrow] Released escrow #${escrowId} → ${releaseTxHash}`);
+    } catch (releaseErr) {
+      console.error("[Escrow] Release failed:", releaseErr);
     }
 
     // Update dataset stats
@@ -233,11 +245,11 @@ paymentsRouter.post("/verify/:id", validateBody(verifySchema), async (req: Reque
       totalEarned: parseFloat((dataset.totalEarned + sellerAmount).toFixed(4)),
     });
 
-    // Log transaction
+    // Log transaction (escrowKey used as txHash for replay protection)
     addTransaction({
       id: `tx-${uuidv4()}`,
       datasetId: dataset.id,
-      txHash,
+      txHash: escrowKey,
       amount: dataset.pricePerQuery,
       buyerQuery: buyerQuestion,
       aiSummary: summary,
@@ -248,16 +260,16 @@ paymentsRouter.post("/verify/:id", validateBody(verifySchema), async (req: Reque
     notifySeller(dataset.sellerWallet, "payment.received", {
       datasetId: dataset.id,
       datasetName: dataset.name,
-      buyerTxHash: txHash,
+      escrowId,
       amount: dataset.pricePerQuery,
       buyerQuery: buyerQuestion,
     }).catch(() => {});
 
-    if (sellerTxHash) {
+    if (releaseTxHash) {
       notifySeller(dataset.sellerWallet, "payment.forwarded", {
         datasetId: dataset.id,
         datasetName: dataset.name,
-        sellerTxHash,
+        releaseTxHash,
         amount: sellerAmount,
       }).catch(() => {});
     }
@@ -267,11 +279,11 @@ paymentsRouter.post("/verify/:id", validateBody(verifySchema), async (req: Reque
       data: dataset.data,
       ai: { summary, answer },
       transaction: {
-        hash: txHash,
+        escrowId,
         amount: dataset.pricePerQuery,
         sellerReceived: sellerAmount,
         platformFee: parseFloat((dataset.pricePerQuery * 0.05).toFixed(4)),
-        sellerTxHash: sellerTxHash ?? null,
+        releaseTxHash: releaseTxHash ?? null,
       },
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

Closes #11

Replaces the off-chain USDC transfer model with live on-chain Soroban contract calls, making the trustless escrow claim real before the hackathon deadline.

**Contract:** `CCPG2CSL6WDUA2IFUDHFN5SCJQUTFCLFKMTARALQ5RWGB2RGG345HEEH` (Stellar testnet)

### What changed

**New: `src/lib/contract.client.ts`**
Typed wrappers around the deployed contract:
- `getEscrow(escrowId)` — simulate-only read, verifies the lock exists, matches the dataset, and has sufficient amount
- `releaseEscrow(escrowId)` — admin calls `release()`, contract splits 95% to seller / 5% to platform on-chain
- `refundEscrow(escrowId)` — admin calls `refund()`, contract returns full amount to buyer
- `lockEscrow()` — stub documenting that `lock()` must be called from the buyer's own wallet
- `usdcToStroops()` — converts USDC float to i128 stroops for amount comparison

**Updated: `src/agent/agent.wallet.ts`**
New `callContract(contractId, method, args)` helper: builds a Soroban invocation transaction, simulates it, assembles auth entries, signs with `AGENT_WALLET_SECRET`, submits via `rpc.sendTransaction`, and polls `rpc.getTransaction` until confirmed or timed out.

**Updated: `src/payments/payments.router.ts`**
- `verifySchema`: `txHash` replaced by `escrowId` (integer — the `u64` returned by `lock()`)
- `POST /api/verify/:id` flow:
  1. Fetch escrow record from contract via `getEscrow()`
  2. Validate: not released, not refunded, dataset_id matches, amount ≥ expected
  3. Run AI — on failure, call `refundEscrow()` before returning 500 (buyer not charged)
  4. On success, call `releaseEscrow()` — contract pays seller and platform on-chain
- `POST /api/verify/:id/demo` — unchanged (no contract calls)

**Updated: `.env.example`** — documents `CONTRACT_ID`

## Test plan

- [ ] Buyer calls `lock()` on the Soroban contract from a funded testnet wallet, note the returned `escrow_id`
- [ ] `POST /api/verify/:datasetId` with `{ "escrowId": <id> }` → 200 with `releaseTxHash` populated, visible in Stellar Explorer
- [ ] Submit the same `escrowId` again → 400 "Escrow already processed"
- [ ] Simulate AI failure (disconnect Anthropic key) → verify `refund()` is called on-chain and buyer balance is restored
- [ ] `POST /api/verify/:datasetId/demo` with only `buyerQuestion` → still works without contract
