### PR TITLE
fix: disable demo mode by default, add confirmation dialog, PostgreSQL storage, and form draft persistence

### DIFF
--- a/backend/src/common/storage.ts
+++ b/backend/src/common/storage.ts
@@ -1,7 +1,9 @@
-import fs from 'fs';
-import path from 'path';
+import { Pool } from 'pg';
 
-const DATA_PATH = path.join(__dirname, '../../../data/datasets.json');
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+});
 
 export interface Dataset {
   id: string;
@@ -43,122 +45,204 @@ export interface WebhookSubscription {
   createdAt: string;
 }
 
-export interface Store {
-  datasets: Dataset[];
-  transactions: Transaction[];
-  webhooks: WebhookSubscription[];
+export async function getDataset(id: string): Promise<Dataset | undefined> {
+  const { rows } = await pool.query<Dataset>(
+    'SELECT * FROM datasets WHERE id = $1',
+    [id],
+  );
+  return rows[0];
 }
 
-function ensureStore(): Store {
-  if (!fs.existsSync(DATA_PATH)) {
-    const empty: Store = { datasets: [], transactions: [], webhooks: [] };
-    fs.writeFileSync(DATA_PATH, JSON.stringify(empty, null, 2), 'utf-8');
-    return empty;
+export async function getAllDatasets(): Promise<Dataset[]> {
+  const { rows } = await pool.query<Dataset>('SELECT * FROM datasets ORDER BY created_at DESC');
+  return rows;
+}
+
+export async function updateDataset(id: string, updates: Partial<Dataset>): Promise<Dataset | null> {
+  const fields = Object.keys(updates) as (keyof Dataset)[];
+  if (fields.length === 0) return getDataset(id) ?? null;
+
+  const setClauses = fields.map((f, i) => `"${toSnake(f)}" = $${i + 2}`).join(', ');
+  const values = fields.map((f) => updates[f]);
+
+  const { rows } = await pool.query<Dataset>(
+    `UPDATE datasets SET ${setClauses} WHERE id = $1 RETURNING *`,
+    [id, ...values],
+  );
+  return rows[0] ?? null;
+}
+
+export async function addDataset(dataset: Dataset): Promise<void> {
+  await pool.query(
+    `INSERT INTO datasets
+       (id, name, description, type, price_per_query, seller_wallet, data,
+        queries_served, total_earned, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+    [
+      dataset.id,
+      dataset.name,
+      dataset.description,
+      dataset.type,
+      dataset.pricePerQuery,
+      dataset.sellerWallet,
+      JSON.stringify(dataset.data),
+      dataset.queriesServed,
+      dataset.totalEarned,
+      dataset.createdAt,
+    ],
+  );
+}
+
+export async function addTransaction(tx: Transaction): Promise<void> {
+  await pool.query(
+    `INSERT INTO transactions
+       (id, dataset_id, tx_hash, amount, buyer_query, ai_summary, timestamp)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+    [tx.id, tx.datasetId, tx.txHash, tx.amount, tx.buyerQuery ?? null, tx.aiSummary ?? null, tx.timestamp],
+  );
+}
+
+export async function getTransactions(
+  datasetId?: string,
+  limit?: number,
+  offset?: number,
+): Promise<Transaction[]> {
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+
+  if (datasetId) {
+    values.push(datasetId);
+    conditions.push(`dataset_id = $${values.length}`);
   }
-  const raw = fs.readFileSync(DATA_PATH, 'utf-8');
-  const parsed = JSON.parse(raw) as Partial<Store>;
-  if (!parsed.webhooks) parsed.webhooks = [];
-  return parsed as Store;
-}
 
-export function readStore(): Store {
-  return ensureStore();
-}
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  let query = `SELECT * FROM transactions ${where} ORDER BY timestamp DESC`;
 
-export function writeStore(store: Store): void {
-  fs.writeFileSync(DATA_PATH, JSON.stringify(store, null, 2), 'utf-8');
-}
-
-export function getDataset(id: string): Dataset | undefined {
-  return readStore().datasets.find((d) => d.id === id);
-}
-
-export function getAllDatasets(): Dataset[] {
-  return readStore().datasets;
-}
-
-export function updateDataset(id: string, updates: Partial<Dataset>): Dataset | null {
-  const store = readStore();
-  const idx = store.datasets.findIndex((d) => d.id === id);
-  if (idx === -1) return null;
-  store.datasets[idx] = { ...store.datasets[idx], ...updates };
-  writeStore(store);
-  return store.datasets[idx];
-}
-
-export function addDataset(dataset: Dataset): void {
-  const store = readStore();
-  store.datasets.push(dataset);
-  writeStore(store);
-}
-
-export function addTransaction(tx: Transaction): void {
-  const store = readStore();
-  store.transactions.push(tx);
-  writeStore(store);
-}
-
-export function getTransactions(datasetId?: string, limit?: number, offset?: number): Transaction[] {
-  const store = readStore();
-  let transactions = datasetId ? store.transactions.filter((t) => t.datasetId === datasetId) : store.transactions;
-  
-  if (offset !== undefined && offset > 0) {
-    transactions = transactions.slice(offset);
-  }
-  
   if (limit !== undefined && limit > 0) {
-    transactions = transactions.slice(0, limit);
+    values.push(limit);
+    query += ` LIMIT $${values.length}`;
   }
-  
-  return transactions;
+  if (offset !== undefined && offset > 0) {
+    values.push(offset);
+    query += ` OFFSET $${values.length}`;
+  }
+
+  const { rows } = await pool.query<Transaction>(query, values);
+  return rows;
 }
 
-export function getTransactionsCount(datasetId?: string): number {
-  const store = readStore();
-  return datasetId ? store.transactions.filter((t) => t.datasetId === datasetId).length : store.transactions.length;
+export async function getTransactionsCount(datasetId?: string): Promise<number> {
+  const { rows } = datasetId
+    ? await pool.query<{ count: string }>('SELECT COUNT(*) FROM transactions WHERE dataset_id = $1', [datasetId])
+    : await pool.query<{ count: string }>('SELECT COUNT(*) FROM transactions');
+  return parseInt(rows[0].count, 10);
 }
 
-export function txHashUsed(txHash: string): boolean {
-  return readStore().transactions.some((t) => t.txHash === txHash);
+export async function txHashUsed(txHash: string): Promise<boolean> {
+  const { rows } = await pool.query<{ count: string }>(
+    'SELECT COUNT(*) FROM transactions WHERE tx_hash = $1',
+    [txHash],
+  );
+  return parseInt(rows[0].count, 10) > 0;
 }
 
 /* ------------------------------------------------------------------ */
 /*  Webhooks                                                           */
 /* ------------------------------------------------------------------ */
 
-export function getAllWebhooks(): WebhookSubscription[] {
-  return readStore().webhooks;
+export async function getAllWebhooks(): Promise<WebhookSubscription[]> {
+  const { rows } = await pool.query<WebhookSubscription>('SELECT * FROM webhooks');
+  return rows;
 }
 
-export function getWebhooksForSeller(sellerWallet: string): WebhookSubscription[] {
-  return readStore().webhooks.filter((w) => w.sellerWallet === sellerWallet && w.active);
+export async function getWebhooksForSeller(sellerWallet: string): Promise<WebhookSubscription[]> {
+  const { rows } = await pool.query<WebhookSubscription>(
+    'SELECT * FROM webhooks WHERE seller_wallet = $1 AND active = true',
+    [sellerWallet],
+  );
+  return rows;
 }
 
-export function getWebhookById(id: string): WebhookSubscription | undefined {
-  return readStore().webhooks.find((w) => w.id === id);
+export async function getWebhookById(id: string): Promise<WebhookSubscription | undefined> {
+  const { rows } = await pool.query<WebhookSubscription>('SELECT * FROM webhooks WHERE id = $1', [id]);
+  return rows[0];
 }
 
-export function addWebhook(webhook: WebhookSubscription): void {
-  const store = readStore();
-  store.webhooks.push(webhook);
-  writeStore(store);
+export async function addWebhook(webhook: WebhookSubscription): Promise<void> {
+  await pool.query(
+    `INSERT INTO webhooks (id, seller_wallet, url, secret, events, active, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+    [webhook.id, webhook.sellerWallet, webhook.url, webhook.secret, webhook.events, webhook.active, webhook.createdAt],
+  );
 }
 
-export function removeWebhook(id: string): boolean {
-  const store = readStore();
-  const idx = store.webhooks.findIndex((w) => w.id === id);
-  if (idx === -1) return false;
-  store.webhooks.splice(idx, 1);
-  writeStore(store);
-  return true;
+export async function removeWebhook(id: string): Promise<boolean> {
+  const { rowCount } = await pool.query('DELETE FROM webhooks WHERE id = $1', [id]);
+  return (rowCount ?? 0) > 0;
 }
 
-export function updateWebhook(id: string, updates: Partial<WebhookSubscription>): WebhookSubscription | null {
-  const store = readStore();
-  const idx = store.webhooks.findIndex((w) => w.id === id);
-  if (idx === -1) return null;
-  store.webhooks[idx] = { ...store.webhooks[idx], ...updates };
-  writeStore(store);
-  return store.webhooks[idx];
+export async function updateWebhook(
+  id: string,
+  updates: Partial<WebhookSubscription>,
+): Promise<WebhookSubscription | null> {
+  const fields = Object.keys(updates) as (keyof WebhookSubscription)[];
+  if (fields.length === 0) return getWebhookById(id) ?? null;
+
+  const setClauses = fields.map((f, i) => `"${toSnake(f)}" = $${i + 2}`).join(', ');
+  const values = fields.map((f) => updates[f]);
+
+  const { rows } = await pool.query<WebhookSubscription>(
+    `UPDATE webhooks SET ${setClauses} WHERE id = $1 RETURNING *`,
+    [id, ...values],
+  );
+  return rows[0] ?? null;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Schema bootstrap (run once on startup)                            */
+/* ------------------------------------------------------------------ */
+
+export async function ensureSchema(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS datasets (
+      id              TEXT PRIMARY KEY,
+      name            TEXT NOT NULL,
+      description     TEXT NOT NULL,
+      type            TEXT NOT NULL,
+      price_per_query NUMERIC NOT NULL,
+      seller_wallet   TEXT NOT NULL,
+      data            JSONB NOT NULL DEFAULT '{}',
+      queries_served  INTEGER NOT NULL DEFAULT 0,
+      total_earned    NUMERIC NOT NULL DEFAULT 0,
+      created_at      TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS transactions (
+      id          TEXT PRIMARY KEY,
+      dataset_id  TEXT NOT NULL REFERENCES datasets(id),
+      tx_hash     TEXT NOT NULL UNIQUE,
+      amount      NUMERIC NOT NULL,
+      buyer_query TEXT,
+      ai_summary  TEXT,
+      timestamp   TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS webhooks (
+      id            TEXT PRIMARY KEY,
+      seller_wallet TEXT NOT NULL,
+      url           TEXT NOT NULL,
+      secret        TEXT NOT NULL,
+      events        TEXT[] NOT NULL DEFAULT '{}',
+      active        BOOLEAN NOT NULL DEFAULT true,
+      created_at    TEXT NOT NULL
+    );
+  `);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function toSnake(camel: string): string {
+  return camel.replace(/([A-Z])/g, '_$1').toLowerCase();
+}

--- a/frontend/src/components/ui/QueryModal.tsx
+++ b/frontend/src/components/ui/QueryModal.tsx
@@ -29,7 +29,7 @@ export default function QueryModal({ dataset, onClose, onSuccess }: Props) {
   const [result, setResult] = useState<QueryResult | null>(null);
   const [error, setError] = useState('');
   const [copied, setCopied] = useState<string | null>(null);
-  const [useDemoMode, setUseDemoMode] = useState(true);
+  const [useDemoMode, setUseDemoMode] = useState(false);
   const [verifyStage, setVerifyStage] = useState(0);
   const verifyTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -48,6 +48,7 @@ export default function SellPage() {
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState("");
+  const [showConfirm, setShowConfirm] = useState(false);
   const [jsonError, setJsonError] = useState("");
 
   const set =
@@ -109,7 +110,8 @@ export default function SellPage() {
     form.dataText.trim() &&
     !jsonError;
 
-  const handleSubmit = async () => {
+  const handleSubmitConfirmed = async () => {
+    setShowConfirm(false);
     if (!isValid || !validateJson(form.dataText)) return;
     setSubmitting(true);
     setError("");
@@ -399,7 +401,7 @@ export default function SellPage() {
                 )}
 
                 <button
-                  onClick={handleSubmit}
+                  onClick={() => setShowConfirm(true)}
                   disabled={!isValid || submitting}
                   className={clsx(
                     "btn-gold w-full flex items-center justify-center gap-2 py-4 text-base",
@@ -418,6 +420,55 @@ export default function SellPage() {
                     </>
                   )}
                 </button>
+
+                {/* Confirmation dialog */}
+                {showConfirm && (
+                  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                    <div
+                      className="absolute inset-0 bg-void/80 backdrop-blur-sm"
+                      onClick={() => setShowConfirm(false)}
+                      aria-hidden="true"
+                    />
+                    <div
+                      role="dialog"
+                      aria-modal="true"
+                      aria-labelledby="confirm-title"
+                      className="relative w-full max-w-sm glass-card-gold p-6 rounded-2xl"
+                    >
+                      <h3
+                        id="confirm-title"
+                        className="font-display font-bold text-lg text-foreground mb-2"
+                      >
+                        Publish dataset?
+                      </h3>
+                      <p className="text-sm text-foreground-muted font-body mb-6">
+                        You are about to list{" "}
+                        <span className="text-foreground font-medium">
+                          {form.name}
+                        </span>{" "}
+                        at{" "}
+                        <span className="text-gold font-semibold">
+                          ${formatUSDC(Number(form.pricePerQuery), locale)} USDC
+                        </span>{" "}
+                        per query. This action cannot be undone.
+                      </p>
+                      <div className="flex gap-3">
+                        <button
+                          onClick={() => setShowConfirm(false)}
+                          className="btn-ghost flex-1 py-2.5 text-sm"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={handleSubmitConfirmed}
+                          className="btn-gold flex-1 py-2.5 text-sm"
+                        >
+                          Publish
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
               </div>
             ) : (
               /* Preview tab */

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Upload,
@@ -39,17 +39,50 @@ const INITIAL: FormState = {
   dataText: "",
 };
 
+const STORAGE_KEY = "hazina_sell_form_draft";
+
+function loadDraft(): FormState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return INITIAL;
+    return { ...INITIAL, ...(JSON.parse(raw) as Partial<FormState>) };
+  } catch {
+    return INITIAL;
+  }
+}
+
+function saveDraft(form: FormState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(form));
+  } catch {
+    // localStorage may be unavailable in certain browser contexts
+  }
+}
+
+function clearDraft(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 export default function SellPage() {
   const { locale, t } = useI18n();
   const catalog = getCatalog(locale);
   const navigate = useNavigate();
-  const [form, setForm] = useState<FormState>(INITIAL);
+  const [form, setForm] = useState<FormState>(loadDraft);
   const [tab, setTab] = useState<Tab>("form");
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState("");
   const [showConfirm, setShowConfirm] = useState(false);
   const [jsonError, setJsonError] = useState("");
+
+  // Persist form draft across page reloads
+  useEffect(() => {
+    saveDraft(form);
+  }, [form]);
 
   const set =
     (key: keyof FormState) =>
@@ -124,6 +157,7 @@ export default function SellPage() {
         sellerWallet: form.sellerWallet.trim(),
         data: JSON.parse(form.dataText),
       });
+      clearDraft();
       setSuccess(true);
     } catch (err: unknown) {
       setError(
@@ -155,6 +189,7 @@ export default function SellPage() {
           <div className="flex gap-3 justify-center">
             <button
               onClick={() => {
+                clearDraft();
                 setForm(INITIAL);
                 setSuccess(false);
               }}


### PR DESCRIPTION
## Summary

- **#139** — Changed useDemoMode initial state from true to false in QueryModal.tsx so users must explicitly opt in to demo mode
- **#143** — Added an inline confirmation dialog in SellPage that shows the dataset name and price before publishing, preventing accidental submissions
- **#160** — Migrated backend/src/common/storage.ts from flat-file JSON to PostgreSQL using the pg Pool. All public functions are async with parameterised queries; ensureSchema() bootstrap creates tables on startup. Configured via DATABASE_URL
- **#152** — Added loadDraft/saveDraft/clearDraft helpers in SellPage persisting form state to localStorage across page reloads. Draft is cleared on successful submission or when the user clicks List Another

## Test plan

- [ ] QueryModal: open the modal; verify demo mode checkbox is unchecked by default
- [ ] SellPage confirmation: fill form and click Publish; verify dialog shows dataset name and price; cancel returns to form; confirm submits
- [ ] SellPage localStorage: fill part of the form, reload the page, verify values are restored; submit and verify draft is cleared
- [ ] PostgreSQL storage: set DATABASE_URL, start backend, verify ensureSchema creates tables, run storage tests against a test database

Closes #139
Closes #143
Closes #160
Closes #152