### PR TITLE
fix(ui): skip earnings update for demo queries and use server-side sellerReceived

### DIFF
--- a/frontend/src/components/ui/QueryModal.tsx
+++ b/frontend/src/components/ui/QueryModal.tsx
@@ -75,7 +75,9 @@ export default function QueryModal({ dataset, onClose, onSuccess }: Props) {
       onSuccess({
         id: dataset.id,
         queriesServed: dataset.queriesServed + 1,
-        totalEarned: dataset.totalEarned + dataset.pricePerQuery * 0.95,
+        totalEarned: res.demo
+          ? dataset.totalEarned
+          : dataset.totalEarned + res.transaction.sellerReceived,
       });
     } catch (err: unknown) {
       clearInterval(verifyTimerRef.current!);


### PR DESCRIPTION
## Problem

`QueryModal.tsx` called `onSuccess` with an optimistic `totalEarned` increase after **every** successful verification — including demo mode queries. Two bugs:

1. **Demo mode**: no real USDC is transferred to the seller, so incrementing `totalEarned` is misleading.
2. **Stale price**: the local recalculation used `dataset.pricePerQuery * 0.95`, which could be stale if the seller updated the price between the modal opening and the API responding.

## Fix

```tsx
// Before
totalEarned: dataset.totalEarned + dataset.pricePerQuery * 0.95,

// After
totalEarned: res.demo
  ? dataset.totalEarned
  : dataset.totalEarned + res.transaction.sellerReceived,
```

- In **demo mode** (`res.demo === true`): `totalEarned` is passed unchanged — no real payment occurred.
- In **real mode**: uses `res.transaction.sellerReceived` from the actual API response, which reflects the server-computed fee split rather than a locally recalculated estimate.

## Affected File

`frontend/src/components/ui/QueryModal.tsx` — lines 75-79

Closes #117