### PR TITLE
feat: add indexes on datasets type, seller_wallet, created_at

### DIFF
--- a/backend/drizzle/0001_add_dataset_indexes.sql
+++ b/backend/drizzle/0001_add_dataset_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS `datasets_type_idx` ON `datasets` (`type`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `datasets_seller_wallet_idx` ON `datasets` (`seller_wallet`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `datasets_created_at_idx` ON `datasets` (`created_at`);

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1704067200000,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1748299432000,
+      "tag": "0001_add_dataset_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -2,7 +2,8 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import Database from 'better-sqlite3';
 import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
 import { Pool } from 'pg';
-import * as schema from './schema';
+import * as pgSchema from './schema';
+import { datasetsSqlite, transactionsSqlite, webhooksSqlite } from './schema';
 
 const databaseUrl = process.env.DATABASE_URL || 'file:./sqlite.db';
 
@@ -10,19 +11,18 @@ const isPostgres = databaseUrl.startsWith('postgres://') || databaseUrl.startsWi
 
 const db = (() => {
   if (isPostgres) {
-    // PostgreSQL
     const pool = new Pool({
       connectionString: databaseUrl,
       ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
     });
-
-    return drizzle(pool, { schema });
+    return drizzle(pool, { schema: pgSchema });
   } else {
-    // SQLite
     const sqliteDbPath = databaseUrl.replace(/^file:/, './');
     const sqlite = new Database(sqliteDbPath);
     sqlite.pragma('journal_mode = WAL');
-    return drizzleSqlite(sqlite, { schema });
+    return drizzleSqlite(sqlite, {
+      schema: { datasets: datasetsSqlite, transactions: transactionsSqlite, webhooks: webhooksSqlite },
+    });
   }
 })();
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -1,85 +1,89 @@
 import { sql } from 'drizzle-orm';
+import { pgTable, text, integer, numeric, boolean, index } from 'drizzle-orm/pg-core';
+import { sqliteTable, text as sqliteText, integer as sqliteInteger, index as sqliteIndex } from 'drizzle-orm/sqlite-core';
 
-const isPostgres = process.env.DATABASE_URL?.startsWith('postgres') ?? false;
+// ── PostgreSQL tables ────────────────────────────────────────────────────────
 
-const getSchemaObjects = () => {
-  if (isPostgres) {
-    const { pgTable, text, integer, numeric, boolean } = require('drizzle-orm/pg-core');
+export const datasets = pgTable(
+  'datasets',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    description: text('description').notNull(),
+    type: text('type').notNull(),
+    pricePerQuery: numeric('price_per_query').notNull(),
+    sellerWallet: text('seller_wallet').notNull(),
+    data: text('data').notNull().default('{}'),
+    queriesServed: integer('queries_served').notNull().default(0),
+    totalEarned: numeric('total_earned').notNull().default('0'),
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => ({
+    typeIdx: index('datasets_type_idx').on(table.type),
+    sellerWalletIdx: index('datasets_seller_wallet_idx').on(table.sellerWallet),
+    createdAtIdx: index('datasets_created_at_idx').on(table.createdAt),
+  }),
+);
 
-    const datasets = pgTable('datasets', {
-      id: text('id').primaryKey(),
-      name: text('name').notNull(),
-      description: text('description').notNull(),
-      type: text('type').notNull(),
-      pricePerQuery: numeric('price_per_query').notNull(),
-      sellerWallet: text('seller_wallet').notNull(),
-      data: text('data').notNull().default('{}'),
-      queriesServed: integer('queries_served').notNull().default(0),
-      totalEarned: numeric('total_earned').notNull().default('0'),
-      createdAt: text('created_at').notNull(),
-    });
+export const transactions = pgTable('transactions', {
+  id: text('id').primaryKey(),
+  datasetId: text('dataset_id').notNull(),
+  txHash: text('tx_hash').notNull().unique(),
+  amount: numeric('amount').notNull(),
+  buyerQuery: text('buyer_query'),
+  aiSummary: text('ai_summary'),
+  timestamp: text('timestamp').notNull(),
+});
 
-    const transactions = pgTable('transactions', {
-      id: text('id').primaryKey(),
-      datasetId: text('dataset_id').notNull(),
-      txHash: text('tx_hash').notNull().unique(),
-      amount: numeric('amount').notNull(),
-      buyerQuery: text('buyer_query'),
-      aiSummary: text('ai_summary'),
-      timestamp: text('timestamp').notNull(),
-    });
+export const webhooks = pgTable('webhooks', {
+  id: text('id').primaryKey(),
+  sellerWallet: text('seller_wallet').notNull(),
+  url: text('url').notNull(),
+  secret: text('secret').notNull(),
+  events: text('events').array().notNull().default(sql`'{}'`),
+  active: boolean('active').notNull().default(true),
+  createdAt: text('created_at').notNull(),
+});
 
-    const webhooks = pgTable('webhooks', {
-      id: text('id').primaryKey(),
-      sellerWallet: text('seller_wallet').notNull(),
-      url: text('url').notNull(),
-      secret: text('secret').notNull(),
-      events: text('events').array().notNull().default(sql`'{}'`),
-      active: boolean('active').notNull().default(true),
-      createdAt: text('created_at').notNull(),
-    });
+// ── SQLite tables (used when DATABASE_URL is not postgres) ───────────────────
 
-    return { datasets, transactions, webhooks };
-  } else {
-    const { sqliteTable, text, integer } = require('drizzle-orm/sqlite-core');
+export const datasetsSqlite = sqliteTable(
+  'datasets',
+  {
+    id: sqliteText('id').primaryKey(),
+    name: sqliteText('name').notNull(),
+    description: sqliteText('description').notNull(),
+    type: sqliteText('type').notNull(),
+    pricePerQuery: sqliteText('price_per_query').notNull(),
+    sellerWallet: sqliteText('seller_wallet').notNull(),
+    data: sqliteText('data').notNull().default('{}'),
+    queriesServed: sqliteInteger('queries_served').notNull().default(0),
+    totalEarned: sqliteText('total_earned').notNull().default('0'),
+    createdAt: sqliteText('created_at').notNull(),
+  },
+  (table) => ({
+    typeIdx: sqliteIndex('datasets_type_idx').on(table.type),
+    sellerWalletIdx: sqliteIndex('datasets_seller_wallet_idx').on(table.sellerWallet),
+    createdAtIdx: sqliteIndex('datasets_created_at_idx').on(table.createdAt),
+  }),
+);
 
-    const datasets = sqliteTable('datasets', {
-      id: text('id').primaryKey(),
-      name: text('name').notNull(),
-      description: text('description').notNull(),
-      type: text('type').notNull(),
-      pricePerQuery: text('price_per_query').notNull(),
-      sellerWallet: text('seller_wallet').notNull(),
-      data: text('data').notNull().default('{}'),
-      queriesServed: integer('queries_served').notNull().default(0),
-      totalEarned: text('total_earned').notNull().default('0'),
-      createdAt: text('created_at').notNull(),
-    });
+export const transactionsSqlite = sqliteTable('transactions', {
+  id: sqliteText('id').primaryKey(),
+  datasetId: sqliteText('dataset_id').notNull(),
+  txHash: sqliteText('tx_hash').notNull().unique(),
+  amount: sqliteText('amount').notNull(),
+  buyerQuery: sqliteText('buyer_query'),
+  aiSummary: sqliteText('ai_summary'),
+  timestamp: sqliteText('timestamp').notNull(),
+});
 
-    const transactions = sqliteTable('transactions', {
-      id: text('id').primaryKey(),
-      datasetId: text('dataset_id').notNull(),
-      txHash: text('tx_hash').notNull().unique(),
-      amount: text('amount').notNull(),
-      buyerQuery: text('buyer_query'),
-      aiSummary: text('ai_summary'),
-      timestamp: text('timestamp').notNull(),
-    });
-
-    const webhooks = sqliteTable('webhooks', {
-      id: text('id').primaryKey(),
-      sellerWallet: text('seller_wallet').notNull(),
-      url: text('url').notNull(),
-      secret: text('secret').notNull(),
-      events: text('events').notNull().default('[]'),
-      active: integer('active').notNull().default(1),
-      createdAt: text('created_at').notNull(),
-    });
-
-    return { datasets, transactions, webhooks };
-  }
-};
-
-const { datasets, transactions, webhooks } = getSchemaObjects();
-
-export { datasets, transactions, webhooks };
+export const webhooksSqlite = sqliteTable('webhooks', {
+  id: sqliteText('id').primaryKey(),
+  sellerWallet: sqliteText('seller_wallet').notNull(),
+  url: sqliteText('url').notNull(),
+  secret: sqliteText('secret').notNull(),
+  events: sqliteText('events').notNull().default('[]'),
+  active: sqliteInteger('active').notNull().default(1),
+  createdAt: sqliteText('created_at').notNull(),
+});

--- a/backend/src/db/seed.ts
+++ b/backend/src/db/seed.ts
@@ -1,9 +1,16 @@
 /* eslint-disable prefer-node-protocol,sonarjs/cognitive-complexity */
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import db from './client';
-import { datasets, transactions } from './schema';
 import { eq } from 'drizzle-orm';
+import db from './client';
+import { datasets, transactions, datasetsSqlite, transactionsSqlite } from './schema';
+
+const isPostgres =
+  (process.env.DATABASE_URL ?? '').startsWith('postgres://') ||
+  (process.env.DATABASE_URL ?? '').startsWith('postgresql://');
+
+const datasetsTable = isPostgres ? datasets : datasetsSqlite;
+const transactionsTable = isPostgres ? transactions : transactionsSqlite;
 
 interface DatasetFromJSON {
   id: string;
@@ -36,8 +43,8 @@ async function seedDatasets(jsonData: any): Promise<void> {
   for (const dataset of jsonData.datasets as DatasetFromJSON[]) {
     const existing = await db
       .select()
-      .from(datasets)
-      .where(eq(datasets.id, dataset.id))
+      .from(datasetsTable as typeof datasets)
+      .where(eq((datasetsTable as typeof datasets).id, dataset.id))
       .limit(1);
 
     if (existing.length > 0) {
@@ -45,7 +52,7 @@ async function seedDatasets(jsonData: any): Promise<void> {
       continue;
     }
 
-    await db.insert(datasets).values({
+    await db.insert(datasetsTable as typeof datasets).values({
       id: dataset.id,
       name: dataset.name,
       description: dataset.description,
@@ -69,8 +76,8 @@ async function seedTransactions(jsonData: any): Promise<void> {
   for (const tx of jsonData.transactions as TransactionFromJSON[]) {
     const existing = await db
       .select()
-      .from(transactions)
-      .where(eq(transactions.txHash, tx.txHash))
+      .from(transactionsTable as typeof transactions)
+      .where(eq((transactionsTable as typeof transactions).txHash, tx.txHash))
       .limit(1);
 
     if (existing.length > 0) {
@@ -78,7 +85,7 @@ async function seedTransactions(jsonData: any): Promise<void> {
       continue;
     }
 
-    await db.insert(transactions).values({
+    await db.insert(transactionsTable as typeof transactions).values({
       id: tx.id,
       datasetId: tx.datasetId,
       txHash: tx.txHash,


### PR DESCRIPTION
## Summary

Adds database indexes on frequently queried fields in the `datasets` table to eliminate full table scans.

## Changes

- **`backend/src/db/schema.ts`** — Refactored to static exports (required by drizzle-kit) and added `index()` on `type`, `sellerWallet`, and `createdAt` for both PostgreSQL and SQLite dialects
- **`backend/drizzle/0001_add_dataset_indexes.sql`** — Migration with three `CREATE INDEX IF NOT EXISTS` statements
- **`backend/drizzle/meta/_journal.json`** — Registered new migration entry
- **`backend/src/db/client.ts`** — Passes dialect-correct schema to each drizzle driver
- **`backend/src/db/seed.ts`** — Uses dialect-aware table references

## Acceptance Criteria

- [x] Indexes exist on `type`, `sellerWallet`, and `createdAt` columns
- [x] Migration file generated and committed
- [x] No existing functionality broken

Closes #281