### PR TITLE
fix: address issues #252, #256, #273, #283

### DIFF
--- a/backend/src/common/constants.ts
+++ b/backend/src/common/constants.ts
@@ -1,0 +1,34 @@
+/**
+ * constants.ts — Issue #273
+ *
+ * Platform fee configuration. Driven by the `PLATFORM_FEE_RATE` environment
+ * variable so the split can be tuned without a code change. Validated at
+ * module load: throws if the value is outside [0, 1].
+ */
+
+const RAW_RATE = process.env.PLATFORM_FEE_RATE ?? '0.05';
+const PARSED_RATE = parseFloat(RAW_RATE);
+
+if (!Number.isFinite(PARSED_RATE) || PARSED_RATE < 0 || PARSED_RATE > 1) {
+  throw new Error(
+    `PLATFORM_FEE_RATE must be a number in [0, 1], got "${RAW_RATE}"`,
+  );
+}
+
+/** Fraction of every payment that the platform keeps (default 5 %). */
+export const PLATFORM_FEE_RATE = PARSED_RATE;
+
+/** Fraction of every payment that goes to the seller (default 95 %). */
+export const SELLER_PAYOUT_RATE = 1 - PLATFORM_FEE_RATE;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Compute the seller's share of `pricePerQuery`, rounded to 7 decimals. */
+export function sellerShare(pricePerQuery: number): number {
+  return parseFloat((pricePerQuery * SELLER_PAYOUT_RATE).toFixed(7));
+}
+
+/** Compute the platform fee from `pricePerQuery`, rounded to 4 decimals. */
+export function platformFee(pricePerQuery: number): number {
+  return parseFloat((pricePerQuery * PLATFORM_FEE_RATE).toFixed(4));
+}

--- a/backend/src/common/errorResponse.ts
+++ b/backend/src/common/errorResponse.ts
@@ -1,0 +1,49 @@
+/**
+ * errorResponse.ts — Issue #283
+ *
+ * Standard error response shape and helper used by all routes.
+ *
+ *   { error: string, code: string, details?: unknown }
+ */
+
+import type { Response } from 'express';
+
+export interface ErrorResponse {
+  /** Human-readable message safe to surface to the frontend. */
+  error: string;
+  /** Machine-readable code (UPPER_SNAKE), e.g. 'INVALID_ADDRESS'. */
+  code: string;
+  /** Optional extra info — never include secrets or stack traces. */
+  details?: unknown;
+}
+
+/**
+ * Send a standardised error response and return the Response object so
+ * callers can `return errorResponse(...)` from a handler.
+ */
+export function errorResponse(
+  res: Response,
+  status: number,
+  error: string,
+  code: string,
+  details?: unknown,
+): Response {
+  const body: ErrorResponse = { error, code };
+  if (details !== undefined) body.details = details;
+  return res.status(status).json(body);
+}
+
+/** Common error codes — reuse rather than inventing per-route strings. */
+export const ErrorCodes = {
+  INVALID_INPUT: 'INVALID_INPUT',
+  INVALID_ADDRESS: 'INVALID_ADDRESS',
+  NOT_FOUND: 'NOT_FOUND',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  FORBIDDEN: 'FORBIDDEN',
+  CONFLICT: 'CONFLICT',
+  PAYMENT_REQUIRED: 'PAYMENT_REQUIRED',
+  RATE_LIMITED: 'RATE_LIMITED',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -179,12 +179,12 @@ app.get('/health', async (_req, res) => {
   });
 });
 
-// Global error handling middleware
+// Global error handling middleware — Issue #283 (standard error shape)
 app.use((err: Error, _req: Request, res: Response, _next: () => void) => {
   const message = err.message || 'Internal server error';
   console.error('[Global Error Handler]', err);
   Sentry.captureException(err);
-  res.status(500).json({ error: message });
+  res.status(500).json({ error: message, code: 'INTERNAL_ERROR' });
 });
 
 // Handle unhandled promise rejections

--- a/backend/src/payments/payments.router.ts
+++ b/backend/src/payments/payments.router.ts
@@ -11,6 +11,7 @@ import {
   txHashUsed,
 } from "../common/storage";
 import { validateBody } from "../common/validate";
+import { sellerShare, platformFee as computePlatformFee } from "../common/constants"; // Issue #273
 import { generateDataSummary } from "../ai/claude.service";
 import { notifySeller } from "../webhooks/webhook.service";
 import { verifyStellarPayment } from "./stellar.service";
@@ -188,8 +189,9 @@ async function deliverVerifiedPayment(params: {
   }
 
   const summaryResult = await generateDataSummary(dataset.data, buyerQuestion);
-  const sellerAmount = parseFloat((dataset.pricePerQuery * 0.95).toFixed(7));
-  const platformFee = parseFloat((dataset.pricePerQuery * 0.05).toFixed(4));
+  // Issue #273 — use named constants instead of hardcoded 0.95 / 0.05
+  const sellerAmount = sellerShare(dataset.pricePerQuery);
+  const platformFee = computePlatformFee(dataset.pricePerQuery);
 
   await updateDataset(dataset.id, {
     queriesServed: dataset.queriesServed + 1,
@@ -277,8 +279,8 @@ async function markDeliveryFailure(params: {
       status: "delivery_failed" as const,
       deliveryStatus: "failed" as const,
       amount: dataset.pricePerQuery,
-      sellerReceived: parseFloat((dataset.pricePerQuery * 0.95).toFixed(7)),
-      platformFee: parseFloat((dataset.pricePerQuery * 0.05).toFixed(4)),
+      sellerReceived: sellerShare(dataset.pricePerQuery),
+      platformFee: computePlatformFee(dataset.pricePerQuery),
       deliveryError: message,
     },
   };
@@ -489,8 +491,8 @@ paymentsRouter.post("/verify/:id/demo", validateBody(verifyDemoSchema), async (r
       "Demo mode: AI summary unavailable. Set ANTHROPIC_API_KEY to enable.";
   }
 
-  const sellerAmount = dataset.pricePerQuery * 0.95;
-  const platformFee = dataset.pricePerQuery * 0.05;
+  const sellerAmount = sellerShare(dataset.pricePerQuery);
+  const platformFee = computePlatformFee(dataset.pricePerQuery);
 
   // Emit payment forwarded
   transactionEventEmitter.forwardPayment(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,34 @@
 const REQUEST_THROTTLE_MS = 250;
 
+// Issue #252 — cap concurrent in-flight HTTP requests so a flood of parallel
+// calls (e.g. dashboard mount firing many fetches at once) can't overwhelm the
+// backend rate limiter or saturate the network. Configurable via
+// VITE_MAX_CONCURRENT_REQUESTS, default 8.
+const MAX_CONCURRENT_REQUESTS = (() => {
+  const env = import.meta.env as unknown as Record<string, string | undefined>;
+  const raw = (env.VITE_MAX_CONCURRENT_REQUESTS ?? '').toString().trim();
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 8;
+})();
+
+let inFlight = 0;
+const inFlightWaiters: Array<() => void> = [];
+
+async function acquireSlot(): Promise<void> {
+  if (inFlight < MAX_CONCURRENT_REQUESTS) {
+    inFlight += 1;
+    return;
+  }
+  await new Promise<void>(resolve => inFlightWaiters.push(resolve));
+  inFlight += 1;
+}
+
+function releaseSlot(): void {
+  inFlight = Math.max(0, inFlight - 1);
+  const next = inFlightWaiters.shift();
+  if (next) next();
+}
+
 const requestQueues = new Map<string, Promise<void>>();
 const requestStartedAt = new Map<string, number>();
 
@@ -271,25 +300,30 @@ function validateDataset(raw: unknown, index?: number): DatasetMeta {
 
 async function request<T>(url: string, options?: RequestOptions): Promise<T> {
   return scheduleRequest(getRequestKey(url, options), async () => {
-    const res = await fetchWithTimeout(url, options);
+    await acquireSlot();
+    try {
+      const res = await fetchWithTimeout(url, options);
 
-    // Parse JSON body once. If parsing fails, we fallback to null.
-    const data = await res.json().catch(() => null);
+      // Parse JSON body once. If parsing fails, we fallback to null.
+      const data = await res.json().catch(() => null);
 
-    if (!res.ok) {
-      throw new Error(data?.error || `HTTP ${res.status}`);
+      if (!res.ok) {
+        throw new Error(data?.error || `HTTP ${res.status}`);
+      }
+
+      if (data === null) {
+        throw new Error('Invalid response from server');
+      }
+
+      // Handle business-level failures returned with 2xx status codes
+      if (data && typeof data === 'object' && data.success === false) {
+        throw new Error(data.error || 'API request failed');
+      }
+
+      return data as T;
+    } finally {
+      releaseSlot();
     }
-
-    if (data === null) {
-      throw new Error('Invalid response from server');
-    }
-
-    // Handle business-level failures returned with 2xx status codes
-    if (data && typeof data === 'object' && data.success === false) {
-      throw new Error(data.error || 'API request failed');
-    }
-
-    return data as T;
   });
 }
 
@@ -405,4 +439,6 @@ export const api = {
 export function __resetRequestThrottleForTests() {
   requestQueues.clear();
   requestStartedAt.clear();
+  inFlight = 0;
+  inFlightWaiters.length = 0;
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## Summary

Bundled fix for four assigned issues.

- **#273 — Platform fee constants.** Added `backend/src/common/constants.ts` exposing `PLATFORM_FEE_RATE`, `SELLER_PAYOUT_RATE`, `sellerShare()`, and `platformFee()`. The rate is read from `PLATFORM_FEE_RATE` (default `0.05`) and validated at module load — startup throws on a value outside `[0, 1]`. The payments router no longer hardcodes `0.95` / `0.05` in the three places it computed splits.
- **#283 — Standard error response shape.** Added `backend/src/common/errorResponse.ts` with the `{ error, code, details? }` contract, an `errorResponse(res, status, error, code, details?)` helper, and an `ErrorCodes` enum. The global Express error handler now emits `code: 'INTERNAL_ERROR'` alongside the message. The helper is exported for incremental adoption in route handlers without churning every route in one PR.
- **#256 — Stricter frontend TS config.** `frontend/tsconfig.json` already had `strict: true`; this PR adds `noUncheckedIndexedAccess` so array/record lookups must be narrowed before use.
- **#252 — Client-side concurrent-request guard.** `frontend/src/lib/api.ts` already throttled per-endpoint at 250 ms. Added a global semaphore (default 8, configurable via `VITE_MAX_CONCURRENT_REQUESTS`) layered over the existing throttle so a burst of parallel calls (e.g. dashboard mount) can't saturate the backend rate limiter or the network. `__resetRequestThrottleForTests` clears the semaphore too.

Closes #252
Closes #256
Closes #273
Closes #283

## Test plan

- [ ] `cd backend && npm run build` — TypeScript compiles
- [ ] `cd frontend && npm run build` — TypeScript compiles under the new strict flag
- [ ] Backend starts with default env; setting `PLATFORM_FEE_RATE=1.5` causes startup to throw
- [ ] Verify a 500 response from any route has shape `{ error, code: 'INTERNAL_ERROR' }`
- [ ] Frontend: trigger many concurrent fetches; in-flight count stays at or below the configured cap