### PR TITLE
fix: extend TTL for each record created in lock_multi

### DIFF
--- a/contracts/hazina-escrow/src/lib.rs
+++ b/contracts/hazina-escrow/src/lib.rs
@@ -431,6 +431,11 @@ impl HazinaEscrow {
             env.storage()
                 .persistent()
                 .set(&EscrowKey::Record(next_id), &record);
+            env.storage().persistent().extend_ttl(
+                &EscrowKey::Record(next_id),
+                ESCROW_MIN_TTL,
+                ESCROW_BUMP_LEDGERS,
+            );
             next_id += 1;
             j += 1;
         }


### PR DESCRIPTION
Closes #320 

Changes made:
- File: contracts/hazina-escrow/src/lib.rs:434-438
  - Added extend_ttl call inside the lock_multi() write loop, matching the pattern used in lock():
env.storage().persistent().extend_ttl(
    &EscrowKey::Record(next_id),
    ESCROW_MIN_TTL,
    ESCROW_BUMP_LEDGERS,
);
Each newly created EscrowRecord in lock_multi() now gets its TTL bumped to ESCROW_BUMP_LEDGERS (518,400 ledgers / ~60 days) with a minimum threshold of ESCROW_MIN_TTL (17,280 ledgers / ~24h), just like records created by lock().