### PR TITLE
fix: check USDC balance before payout and retry on transient Horizon 404

### DIFF
--- a/backend/src/agent/agent.wallet.ts
+++ b/backend/src/agent/agent.wallet.ts
@@ -30,6 +30,21 @@ export async function sendUsdcPayment(params: SendPaymentParams): Promise<SendPa
   const keypair = StellarSdk.Keypair.fromSecret(secret);
   const account = await server.loadAccount(keypair.publicKey());
 
+  const usdcBal = account.balances.find(b => {
+    if (b.asset_type === 'native') return false;
+    const bal = b as { asset_code: string; asset_issuer: string };
+    return bal.asset_code === 'USDC' && bal.asset_issuer === USDC_ISSUER;
+  }) as { balance: string } | undefined;
+
+  if (!usdcBal) {
+    throw new Error('Agent wallet has no USDC trustline — cannot send payment');
+  }
+  if (parseFloat(usdcBal.balance) < parseFloat(params.amount)) {
+    throw new Error(
+      `Insufficient USDC balance: need ${params.amount} USDC, have ${usdcBal.balance} USDC`,
+    );
+  }
+
   const usdc = new StellarSdk.Asset('USDC', USDC_ISSUER);
 
   const txBuilder = new StellarSdk.TransactionBuilder(account, {

--- a/backend/src/payments/stellar.service.ts
+++ b/backend/src/payments/stellar.service.ts
@@ -57,17 +57,40 @@ export class StellarTimeoutError extends Error {
   }
 }
 
+async function withHorizonRetry<T>(fn: () => Promise<T>): Promise<T> {
+  const maxAttempts = 3;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err: unknown) {
+      const is404 =
+        err &&
+        typeof err === 'object' &&
+        'response' in err &&
+        (err as { response?: { status?: number } }).response?.status === 404;
+      if (is404 && attempt < maxAttempts - 1) {
+        await new Promise(r => setTimeout(r, 1_000 * (attempt + 1)));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error('unreachable');
+}
+
 export async function verifyStellarPayment(params: VerifyParams): Promise<VerifyResult> {
   const { txHash, expectedAmount, destinationAddress } = params;
 
   try {
     const [tx, ops] = await withStellarTimeout(
       () =>
-        stellarBreaker.execute(() =>
-          Promise.all([
-            server.transactions().transaction(txHash).call(),
-            server.operations().forTransaction(txHash).call(),
-          ]),
+        withHorizonRetry(() =>
+          stellarBreaker.execute(() =>
+            Promise.all([
+              server.transactions().transaction(txHash).call(),
+              server.operations().forTransaction(txHash).call(),
+            ]),
+          ),
         ),
       STELLAR_TIMEOUT_MS,
     );


### PR DESCRIPTION
- agent.wallet.ts: validate agent wallet has a USDC trustline and sufficient balance before submitting the payment transaction, preventing a hard Stellar error after the buyer has already paid (closes #386)
- stellar.service.ts: add withHorizonRetry (3 attempts, 1s/2s backoff) around the Horizon API fetch so a transient not_found before ledger indexing does not incorrectly reject a valid payment (closes #385)

## Summary

<!-- 2-5 sentences on what changed and why. -->

## Related Issue

Closes #387 
Closes #386 
Closes #385 
Closes #384 

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Tests only
- [ ] Documentation
- [ ] CI / tooling / infrastructure

## What Changed

<!-- Call out the key implementation changes, grouped by area if useful. -->

- 

## Testing

<!-- List exactly what you ran and any manual verification a reviewer should repeat. -->

### Automated

- [ ] `cd backend && npm test`
- [ ] `cd frontend && npm test`
- [ ] `cd backend && npm run build`
- [ ] `cd frontend && npm run build`
- [ ] `cd contracts/hazina-escrow && cargo test`
- [ ] Not applicable

### Manual

1. 
2. 
3. 

Demo mode reminder: marketplace and agent flows can be exercised without a funded Stellar wallet where demo endpoints are available.

## Risk & Rollout Notes

<!-- Note migrations, env changes, API contract changes, data changes, or rollback concerns. -->

- User-facing risk:
- Operational risk:
- Rollback plan:

## Screenshots / Recordings

<!-- Required for visual changes when practical. Add before/after images or a short video. -->

## Checklist

- [ ] I verified the change against the relevant parts of the app
- [ ] I updated or added tests where the behavior changed, or explained why tests were not needed
- [ ] I updated docs, comments, examples, or API references if needed
- [ ] I did not commit secrets, private keys, or production-only values
- [ ] I used existing logging/error-handling patterns instead of leaving debug-only output behind
- [ ] I reviewed the diff for accidental changes before requesting review
