### PR TITLE
fix: resolve frontend issues #340, #345, #348, #350 (WebSocket queue, NavLink active state, NaN guard, SkeletonLoader CLS)

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, NavLink, useLocation } from "react-router-dom";
 import {
   Database,
   BarChart3,
@@ -142,20 +142,22 @@ export default function Navbar() {
 
           <div className="hidden xl:flex items-center gap-1.5 flex-nowrap">
             {NAV_LINKS.map(({ to, key, icon: Icon, dataTour }) => (
-              <Link
+              <NavLink
                 key={to}
                 to={to}
                 data-tour={dataTour}
-                className={clsx(
-                  "flex shrink-0 items-center gap-2 whitespace-nowrap px-3 py-2 rounded-xl text-sm font-medium font-body transition-all duration-200",
-                  pathname === to
-                    ? "bg-gold/15 text-gold border border-gold/25"
-                    : "text-foreground-muted hover:text-foreground hover:bg-surface-2",
-                )}
+                className={({ isActive }) =>
+                  clsx(
+                    "flex shrink-0 items-center gap-2 whitespace-nowrap px-3 py-2 rounded-xl text-sm font-medium font-body transition-all duration-200",
+                    isActive
+                      ? "bg-gold/15 text-gold border border-gold/25"
+                      : "text-foreground-muted hover:text-foreground hover:bg-surface-2",
+                  )
+                }
               >
                 <Icon className="w-4 h-4" aria-hidden="true" />
                 {t(key)}
-              </Link>
+              </NavLink>
             ))}
           </div>
 
@@ -292,17 +294,19 @@ export default function Navbar() {
 
             <div className="flex flex-col gap-2">
               {NAV_LINKS.map(({ to, key, icon: Icon, dataTour }) => (
-                <Link
+                <NavLink
                   key={to}
                   to={to}
                   data-tour={dataTour}
                   onClick={() => setMobileOpen(false)}
-                  className={clsx(
-                    "flex items-center justify-between gap-3 rounded-2xl px-4 py-3.5 text-sm font-medium font-body transition-all duration-200",
-                    pathname === to
-                      ? "bg-gold/15 text-gold border border-gold/25"
-                      : "text-foreground-muted hover:text-foreground hover:bg-surface-2 border border-transparent",
-                  )}
+                  className={({ isActive }) =>
+                    clsx(
+                      "flex items-center justify-between gap-3 rounded-2xl px-4 py-3.5 text-sm font-medium font-body transition-all duration-200",
+                      isActive
+                        ? "bg-gold/15 text-gold border border-gold/25"
+                        : "text-foreground-muted hover:text-foreground hover:bg-surface-2 border border-transparent",
+                    )
+                  }
                 >
                   <span className="flex min-w-0 items-center gap-3">
                     <Icon className="w-4 h-4 shrink-0" aria-hidden="true" />
@@ -311,7 +315,7 @@ export default function Navbar() {
                   <span className="text-gold/60 text-base" aria-hidden="true">
                     +
                   </span>
-                </Link>
+                </NavLink>
               ))}
             </div>
 

--- a/frontend/src/components/ui/SkeletonLoader.tsx
+++ b/frontend/src/components/ui/SkeletonLoader.tsx
@@ -37,7 +37,8 @@ export function Skeleton({
       )}
       style={{
         width: width || (variant === "text" ? "100%" : undefined),
-        height: height || (variant === "circular" ? width : undefined),
+        minHeight: height || (variant === "circular" ? width : undefined),
+        height: variant === "circular" ? (height ?? width) : undefined,
       }}
     />
   );

--- a/frontend/src/hooks/useTransactionWebSocket.ts
+++ b/frontend/src/hooks/useTransactionWebSocket.ts
@@ -57,6 +57,7 @@ export function useTransactionWebSocket(
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout>();
   const reconnectAttemptsRef = useRef(0);
+  const pendingSubscriptionsRef = useRef<Array<{ datasetIds?: string[]; transactionIds?: string[] }>>([]);
   // Store callbacks in ref to avoid dependency issues
   const callbacksRef = useRef(callbacks);
   const maxReconnectAttempts = 5;
@@ -100,6 +101,17 @@ export function useTransactionWebSocket(
           ...(options.apiToken && { token: options.apiToken }),
         };
         ws.send(JSON.stringify(subscribeMsg));
+
+        // Flush any subscriptions that were requested while CONNECTING
+        pendingSubscriptionsRef.current.forEach((ids: { datasetIds?: string[]; transactionIds?: string[] }) => {
+          const msg = {
+            type: 'subscribe',
+            ...ids,
+            ...(options.apiToken && { token: options.apiToken }),
+          };
+          ws.send(JSON.stringify(msg));
+        });
+        pendingSubscriptionsRef.current = [];
       };
 
       ws.onmessage = event => {
@@ -181,7 +193,17 @@ export function useTransactionWebSocket(
    */
   const subscribe = useCallback(
     (ids: { datasetIds?: string[]; transactionIds?: string[] }): void => {
-      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      if (!wsRef.current) {
+        console.warn('[WebSocket] Not connected, cannot subscribe');
+        return;
+      }
+
+      if (wsRef.current.readyState === WebSocket.CONNECTING) {
+        pendingSubscriptionsRef.current.push(ids);
+        return;
+      }
+
+      if (wsRef.current.readyState !== WebSocket.OPEN) {
         console.warn('[WebSocket] Not connected, cannot subscribe');
         return;
       }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -56,10 +56,11 @@ function StatCard({
   prefix?: string;
   decimals?: number;
   color?: string;
-  trend?: number;
+  trend?: number | null;
   locale?: string;
 }) {
   const animated = useCountUp(value, 1800, decimals);
+  const trendValid = trend !== undefined && trend !== null && isFinite(trend) && !isNaN(trend);
   return (
     <div className="glass-card-gold p-5">
       <div className="flex items-start justify-between mb-3">
@@ -70,11 +71,17 @@ function StatCard({
           <span
             className={clsx(
               'text-xs font-body font-medium flex items-center gap-0.5 px-2 py-1 rounded-full',
-              trend >= 0 ? 'text-emerald-400 bg-emerald-400/10' : 'text-red-400 bg-red-400/10',
+              !trendValid
+                ? 'text-foreground-muted bg-surface-2'
+                : trend >= 0
+                  ? 'text-emerald-400 bg-emerald-400/10'
+                  : 'text-red-400 bg-red-400/10',
             )}
           >
-            <ArrowUpRight className={clsx('w-3 h-3', trend < 0 && 'rotate-180')} />
-            {Math.abs(trend)}%
+            {trendValid && (
+              <ArrowUpRight className={clsx('w-3 h-3', trend < 0 && 'rotate-180')} />
+            )}
+            {trendValid ? `${Math.abs(trend).toFixed(1)}%` : '—'}
           </span>
         )}
       </div>
@@ -119,6 +126,12 @@ function ChartTooltip({
       ))}
     </div>
   );
+}
+
+/* ── Safe percentage change (returns null when previous is 0 to avoid NaN/Infinity) ── */
+function safePctChange(current: number, previous: number): number | null {
+  if (previous === 0) return null;
+  return ((current - previous) / previous) * 100;
 }
 
 /* ── Generate 7-day chart data from transactions ── */
@@ -175,7 +188,6 @@ export default function DashboardPage() {
   );
 
   const loadDashboard = async () => {
-  const loadDashboard = async () => {
     if (hasLoadedOnceRef.current) {
       setIsRefetching(true);
     } else {
@@ -205,6 +217,15 @@ export default function DashboardPage() {
   const totalEarned = datasets.reduce((s, d) => s + d.totalEarned, 0);
   const totalQueries = datasets.reduce((s, d) => s + d.queriesServed, 0);
   const chartData = buildChartData(transactions, locale);
+
+  // Compare last 3 days vs preceding 4 days for trend indicators
+  const recentEarned = chartData.slice(-3).reduce((s, d) => s + d.earned, 0);
+  const prevEarned = chartData.slice(0, 4).reduce((s, d) => s + d.earned, 0);
+  const earnedTrend = safePctChange(recentEarned, prevEarned);
+
+  const recentQueries = chartData.slice(-3).reduce((s, d) => s + d.queries, 0);
+  const prevQueries = chartData.slice(0, 4).reduce((s, d) => s + d.queries, 0);
+  const queriesTrend = safePctChange(recentQueries, prevQueries);
   const recentTx = [...transactions]
     .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
     .slice(0, 8);
@@ -362,6 +383,7 @@ export default function DashboardPage() {
             prefix="$"
             decimals={4}
             color="text-gold"
+            trend={earnedTrend}
             locale={locale}
           />
           <StatCard
@@ -369,6 +391,7 @@ export default function DashboardPage() {
             label={t('dashboard.stats.totalQueries')}
             value={totalQueries}
             suffix={t('common.units.queries')}
+            trend={queriesTrend}
             locale={locale}
           />
           <StatCard


### PR DESCRIPTION
## Summary

This PR resolves four open frontend issues assigned to me in the Stellar Wave program:

### Fix #340 — WebSocket `subscribe()` silently drops messages during CONNECTING state
**File:** `frontend/src/hooks/useTransactionWebSocket.ts`
- Added a `pendingSubscriptionsRef` queue that stores `subscribe()` calls made while the socket is in `CONNECTING` state (`readyState === 0`)
- The queue is flushed inside the `ws.onopen` handler immediately after the initial subscription message is sent
- Previously these calls were silently dropped with only a console warning

### Fix #345 — Navbar has no active route indicator
**File:** `frontend/src/components/layout/Navbar.tsx`
- Replaced `Link` with `NavLink` from React Router in both the desktop and mobile navigation menus
- Active styling (`bg-gold/15 text-gold border border-gold/25`) is now driven by `NavLink`'s `isActive` callback, which correctly handles exact and nested route matches
- Removed the manual `pathname === to` comparison (the `useLocation` hook is still used for the mobile-menu close effect)

### Fix #348 — DashboardPage stats show `NaN` when `totalUsdcEarned` is zero
**File:** `frontend/src/pages/DashboardPage.tsx`
- Added `safePctChange(current, previous)` helper that returns `null` when `previous === 0`, preventing `NaN`/`Infinity` from dividing by zero
- Updated `StatCard` to accept `trend?: number | null`; invalid values (`null`, `NaN`, `Infinity`) render as `—` instead of a raw number
- Computed period-over-period earned and queries trends from the 7-day chart data and passed them to the first two stat cards
- Also removed a duplicate `const loadDashboard = async () => {` declaration (pre-existing compile error)

### Fix #350 — SkeletonLoader fixed heights cause layout shift on content load
**File:** `frontend/src/components/ui/SkeletonLoader.tsx`
- Changed the `Skeleton` component's inline `height` style to `minHeight` so variable-height real content (long dataset names, multi-line descriptions) can grow without triggering Cumulative Layout Shift (CLS)
- Circular skeletons retain an explicit `height` equal to `width` to preserve their square bounding box and `border-radius: 50%` appearance

## Test plan

- [ ] WebSocket: open DevTools Network tab, connect, observe that subscriptions queued before `onopen` are flushed and sent correctly
- [ ] Navbar: navigate between pages and confirm the active link is highlighted on both desktop and mobile viewports
- [ ] Dashboard: load with zero-earned datasets; confirm stat cards show `—` instead of `NaN%` or `Infinity%`
- [ ] Dashboard: load with real data; confirm trend badges show correct signed percentages
- [ ] Skeleton: inspect skeleton elements in DevTools and verify `min-height` is set; confirm no visible CLS when content loads

Closes #340
Closes #345
Closes #348
Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)