### PR TITLE
fix: guard seed script against accidental production execution

### DIFF
--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -19,6 +19,13 @@ const generateStellarAddress = () => {
 };
 
 const seed = async () => {
+  if (process.env.NODE_ENV === 'production') {
+    console.error(
+      '[seed] Refusing to run in production (NODE_ENV=production). Aborting to protect live data.',
+    );
+    process.exit(1);
+  }
+
   const clean = process.argv.includes('--clean');
   logger.info(
     `Starting seeding... ${clean ? '(Cleaning existing data)' : '(Appending to existing data)'}`,


### PR DESCRIPTION
## Summary

Closes #371

- `seed()` now exits immediately with a clear error message if `NODE_ENV=production`, preventing accidental overwrite of live `datasets.json`
- Uses `console.error` (not `logger`) so the abort message is always visible regardless of logger initialisation order

## Changes

`backend/src/seed.ts` — added guard at the top of `seed()`:

```ts
if (process.env.NODE_ENV === 'production') {
  console.error(
    '[seed] Refusing to run in production (NODE_ENV=production). Aborting to protect live data.',
  );
  process.exit(1);
}
```

## Test plan

- [ ] Run `NODE_ENV=production ts-node src/seed.ts` — should exit with error message, no data written
- [ ] Run `NODE_ENV=development ts-node src/seed.ts` — should seed normally
- [ ] Run without `NODE_ENV` set — should seed normally (undefined !== 'production')
