### PR TITLE
fix: replace REACT_APP_ env var with VITE_ in WebSocket hook

### DIFF
--- a/frontend/src/hooks/useTransactionWebSocket.ts
+++ b/frontend/src/hooks/useTransactionWebSocket.ts
@@ -83,7 +83,7 @@ export function useTransactionWebSocket(
 
     try {
       const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-      const host = process.env.REACT_APP_WEBSOCKET_URL || `${protocol}://${window.location.host}`;
+      const host = import.meta.env.VITE_WEBSOCKET_URL || `${protocol}://${window.location.host}`;
       const wsUrl = `${host}/ws`;
 
       const ws = new WebSocket(wsUrl);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_API_KEY?: string;
   readonly VITE_STELLAR_NETWORK?: string;
   readonly VITE_USDC_ISSUER?: string;
+  readonly VITE_WEBSOCKET_URL?: string;
   // Vite built-ins
   readonly DEV: boolean;
   readonly PROD: boolean;


### PR DESCRIPTION
Closes #326

process.env.REACT_APP_WEBSOCKET_URL is always undefined in Vite — CRA convention does not apply. Replaced with import.meta.env.VITE_WEBSOCKET_URL and added the corresponding type declaration to vite-env.d.ts so TypeScript resolves the property without error.

