### PR TITLE
feat: make agent fee configurable via AGENT_FEE_USDC

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,9 @@ PLATFORM_FEE=0.05
 # Then add USDC trustline and fund via testnet USDC faucet
 AGENT_WALLET_SECRET=your_agent_wallet_secret_here
 
+# Agent fee in USDC — flat fee per research job (default: 1)
+AGENT_FEE_USDC=1
+
 # Database Backup Configuration
 # Enable/disable automated backups (default: true)
 BACKUP_ENABLED=true

--- a/backend/src/agent/agent.service.ts
+++ b/backend/src/agent/agent.service.ts
@@ -18,8 +18,11 @@ import {
 import { notifySeller } from '../webhooks/webhook.service';
 import { domainMetrics } from '../common/datadog';
 
-// Fee the agent charges the human (1 USDC flat)
-export const AGENT_FEE_USDC = 1;
+// Fee the agent charges the human (1 USDC flat by default).
+// Override via AGENT_FEE_USDC environment variable (e.g. "2.5").
+const RAW_FEE = process.env.AGENT_FEE_USDC ?? '1';
+const PARSED_FEE = parseFloat(RAW_FEE);
+export const AGENT_FEE_USDC = Number.isFinite(PARSED_FEE) && PARSED_FEE >= 0 ? PARSED_FEE : 1;
 
 // Dataset types the agent purchases and their roles in the report
 export const SELLER_TYPES = [


### PR DESCRIPTION

## Summary

Replaces the hardcoded AGENT_FEE_USDC value with an environment-variable-based configuration while preserving existing behavior.

## Changes Made

### backend/src/agent/agent.service.ts

* Replaced hardcoded fee constant with environment variable parsing
* Reads from `process.env.AGENT_FEE_USDC`
* Falls back to 1 when missing or invalid
* Rejects negative values

### backend/.env.example

* Added `AGENT_FEE_USDC` example configuration
* Added documentation comment explaining usage

## Validation

| Scenario           | Result    |
| ------------------ | --------- |
| Variable unset     | Uses 1    |
| Empty value        | Uses 1    |
| Valid value (2.5)  | Uses 2.5  |
| Valid value (0.75) | Uses 0.75 |
| Invalid value      | Uses 1    |
| Negative value     | Uses 1    |
| Zero               | Uses 0    |

## Benefits

* Fee can be adjusted without code changes
* No deployment required for fee updates
* Preserves existing behavior by default
* No API contract changes
* No additional dependencies

Closes #373 


