### PR TITLE
fix(sentry): attach request context to captureException calls

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -243,13 +243,21 @@ process.on('unhandledRejection', (reason: unknown) => {
   logger.error(
     `[Unhandled Rejection]: ${reason instanceof Error ? reason.message : String(reason)}`,
   );
-  Sentry.captureException(reason);
+  Sentry.withScope(scope => {
+    scope.setTag('source', 'unhandledRejection');
+    scope.setLevel('error');
+    Sentry.captureException(reason);
+  });
 });
 
 // Handle uncaught exceptions
 process.on('uncaughtException', (err: Error) => {
   logger.error(`[Uncaught Exception]: ${err.message}`);
-  Sentry.captureException(err);
+  Sentry.withScope(scope => {
+    scope.setTag('source', 'uncaughtException');
+    scope.setLevel('fatal');
+    Sentry.captureException(err);
+  });
 });
 
 // Routes under versioned API namespace.
@@ -290,7 +298,17 @@ app.use(
     // object is intentional — pino serialises it safely. Never interpolate
     // err.message into a template string here as it may include key material.
     logger.error({ requestId: req.id, status, err }, 'Unhandled request error');
-    Sentry.captureException(err);
+    Sentry.withScope(scope => {
+      scope.setTag('requestId', req.id);
+      scope.setTag('method', req.method);
+      scope.setTag('url', req.originalUrl);
+      scope.setContext('request', {
+        id: req.id,
+        method: req.method,
+        url: req.originalUrl,
+      });
+      Sentry.captureException(err);
+    });
     res
       .status(status)
       .json({ error: message, code: err.code || 'INTERNAL_ERROR', requestId: req.id });


### PR DESCRIPTION
## Summary

- Wraps all `Sentry.captureException` calls with `Sentry.withScope` so every Sentry event carries actionable context
- Global error handler now tags each event with `requestId`, HTTP `method`, and `url` — making it possible to identify which wallet, dataset, or payment was involved during root-cause analysis
- Process-level handlers (`unhandledRejection` / `uncaughtException`) are tagged with their `source` and appropriate severity level (`error` / `fatal`)

Closes #396
Closes #399

## Test plan

- [ ] Trigger a 500 error on any endpoint — confirm the Sentry event includes `requestId`, `method`, and `url` tags
- [ ] Verify no secrets appear in Sentry events (covered by existing `beforeSend` scrubber in `sentry.ts`)
- [ ] Confirm all backup routes (`GET /api/v1/backups`, `POST /api/v1/backups/create`, etc.) still return 401 without `Authorization: Bearer <ADMIN_API_KEY>`
