### PR TITLE
ci: add container image vulnerability scanning with Trivy

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,103 @@
+name: Container Image Scan
+
+# Builds the production Docker images for the backend and frontend, then scans
+# each image for known OS/library CVEs with Trivy. The build fails on any
+# unfixed-aware HIGH or CRITICAL vulnerability so that a vulnerable base image
+# layer cannot reach deployment undetected.
+
+on:
+  pull_request:
+    branches: ['*']
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - '.github/workflows/container-scan.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - '.github/workflows/container-scan.yml'
+  # Allow running the full scan on demand (e.g. after a base image advisory).
+  workflow_dispatch:
+  # Re-scan already-built images on a weekly cadence to catch CVEs disclosed
+  # after the image was last built.
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: container-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan ${{ matrix.name }} image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to publish scan results to the GitHub Security tab.
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            image: hazina-backend:scan
+          - name: frontend
+            context: ./frontend
+            image: hazina-frontend:scan
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.name }} production image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          target: production
+          push: false
+          load: true
+          tags: ${{ matrix.image }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      # Produce SARIF for the Security tab. This never fails the build so that
+      # the report is always uploaded, even when vulnerabilities are present.
+      - name: Scan ${{ matrix.name }} image (SARIF report)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-${{ matrix.name }}.sarif
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && github.event_name != 'pull_request'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.name }}.sarif
+          category: trivy-${{ matrix.name }}
+
+      # Gate the pipeline: fail on any fixable HIGH/CRITICAL vulnerability and
+      # print a human-readable table in the job log.
+      - name: Scan ${{ matrix.name }} image (fail on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: table
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          exit-code: '1'
+          # Reuse the vulnerability DB downloaded by the SARIF step above.
+          skip-db-update: true

--- a/README.md
+++ b/README.md
@@ -433,6 +433,24 @@ docker compose down
 docker compose -f docker-compose.prod.yml down
 ```
 
+### Image vulnerability scanning
+
+The production backend and frontend images are scanned for known CVEs by the
+[`Container Image Scan`](.github/workflows/container-scan.yml) GitHub Actions
+workflow. On every pull request and push to `main` that touches `backend/` or
+`frontend/`, each image is built and scanned with
+[Trivy](https://github.com/aquasecurity/trivy); the build fails on any fixable
+`HIGH` or `CRITICAL` OS/library vulnerability. Results are also published to the
+repository's **Security → Code scanning** tab, and a weekly scheduled run
+re-scans the images to catch CVEs disclosed after the last build.
+
+To reproduce a scan locally:
+
+```bash
+docker build -t hazina-backend:scan --target production ./backend
+trivy image --severity HIGH,CRITICAL --ignore-unfixed hazina-backend:scan
+```
+
 ---
 
 ## Pages & Features


### PR DESCRIPTION
## Summary

Resolves #404 — the backend and frontend Docker images were built but never scanned for CVEs, so a known vulnerability in a base image layer could go undetected indefinitely.

This adds a **Container Image Scan** GitHub Actions workflow (`.github/workflows/container-scan.yml`) that builds the production images for both services and scans each with [Trivy](https://github.com/aquasecurity/trivy).

## What it does

- **Builds** the `production` target of `backend/Dockerfile` and `frontend/Dockerfile` (matrix job, one per service) using Buildx with GHA layer caching.
- **Scans** each image for `HIGH`/`CRITICAL` OS and library CVEs.
- **Gates deployment**: the job fails on any *fixable* HIGH/CRITICAL vulnerability (`ignore-unfixed: true`), printing a readable table in the log.
- **Reports**: uploads SARIF results to the **Security → Code scanning** tab (on pushes/scheduled runs, where the token has `security-events: write`).

## Triggers

- Pull requests and pushes to `main` touching `backend/**` or `frontend/**`
- `workflow_dispatch` (on-demand, e.g. after a base-image advisory)
- Weekly `schedule` to catch CVEs disclosed after the last build

## Testing

- YAML validated with `yaml.safe_load`.
- Build contexts confirmed self-contained (lockfiles + `nginx.conf` present).
- Docker isn't available in the local dev sandbox, so the build/scan runs in CI on this PR. Local reproduction steps are documented in the README.