### PR TITLE
feat: add agent job budget guard to prevent overspend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -52,7 +52,7 @@
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/coverage-v8": "^1.2.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "supertest": "^6.3.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,7 +52,7 @@
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "@vitest/coverage-v8": "^1.2.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "supertest": "^6.3.3",

--- a/backend/src/agent/agent.router.ts
+++ b/backend/src/agent/agent.router.ts
@@ -302,4 +302,3 @@ agentRouter.post(
     return res.status(500).json({ error: message });
   }
 });
-\nimport { logger } from '../lib/logger';

--- a/backend/src/agent/agent.service.test.ts
+++ b/backend/src/agent/agent.service.test.ts
@@ -51,10 +51,11 @@ vi.mock('../common/datadog', () => ({
     agentJobCompleted: vi.fn(),
     agentDatasetPurchase: vi.fn(),
     agentHumanPaymentVerified: vi.fn(),
+    agentBudgetInsufficient: vi.fn(),
   },
 }));
 
-import { runResearchAgentDemo, SELLER_TYPES } from './agent.service';
+import { runResearchAgentDemo, SELLER_TYPES, AGENT_FEE_USDC } from './agent.service';
 import { getAllDatasets, getDataset } from '../common/storage';
 import { domainMetrics } from '../common/datadog';
 
@@ -98,5 +99,70 @@ describe('runResearchAgentDemo metrics', () => {
       datasetsQueried: SELLER_TYPES.length,
       totalSpent: expect.any(Number),
     });
+  });
+});
+
+describe('budget guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips expensive datasets so agentProfit is never negative', async () => {
+    // All 4 sellers priced at 0.30 USDC → total 1.20 > AGENT_FEE_USDC (1.00)
+    const expensiveDatasets: Dataset[] = SELLER_TYPES.map(seller => ({
+      id: `ds-${seller.type}`,
+      name: `${seller.description} Dataset`,
+      description: seller.description,
+      type: seller.type,
+      pricePerQuery: 0.3,
+      sellerWallet: SELLER_WALLET,
+      data: { rows: [] },
+      queriesServed: 0,
+      totalEarned: 0,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
+
+    vi.mocked(getAllDatasets).mockResolvedValue(expensiveDatasets);
+    vi.mocked(getDataset).mockImplementation(async (id: string) =>
+      expensiveDatasets.find(d => d.id === id),
+    );
+
+    const job = await runResearchAgentDemo('overspend scenario');
+
+    // Only datasets that fit within AGENT_FEE_USDC should be purchased
+    expect(job.totalSpent).toBeLessThanOrEqual(AGENT_FEE_USDC);
+    expect(job.agentProfit).toBeGreaterThanOrEqual(0);
+    // Some datasets must have been skipped
+    expect(job.purchases.length).toBeLessThan(SELLER_TYPES.length);
+    // Budget metric must have been emitted
+    expect(domainMetrics.agentBudgetInsufficient).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'demo', skipped: expect.any(Number) }),
+    );
+  });
+
+  it('does not emit agentBudgetInsufficient when all datasets fit within fee', async () => {
+    // Very cheap datasets — all fit easily
+    const cheapDatasets: Dataset[] = SELLER_TYPES.map(seller => ({
+      id: `ds-${seller.type}`,
+      name: `${seller.description} Dataset`,
+      description: seller.description,
+      type: seller.type,
+      pricePerQuery: 0.01,
+      sellerWallet: SELLER_WALLET,
+      data: { rows: [] },
+      queriesServed: 0,
+      totalEarned: 0,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
+
+    vi.mocked(getAllDatasets).mockResolvedValue(cheapDatasets);
+    vi.mocked(getDataset).mockImplementation(async (id: string) =>
+      cheapDatasets.find(d => d.id === id),
+    );
+
+    const job = await runResearchAgentDemo('cheap scenario');
+
+    expect(job.agentProfit).toBeGreaterThanOrEqual(0);
+    expect(domainMetrics.agentBudgetInsufficient).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/agent/agent.service.ts
+++ b/backend/src/agent/agent.service.ts
@@ -202,8 +202,12 @@ async function _executeResearch(
 
   // Budget guard: greedily select datasets that fit within AGENT_FEE_USDC,
   // sorted cheapest-first so we maximise coverage.
+  type SellerWithDataset = {
+    seller: (typeof availableSellers)[0]['seller'];
+    dataset: NonNullable<(typeof availableSellers)[0]['dataset']>;
+  };
   const sellersWithDataset = availableSellers.filter(
-    (s): s is { seller: (typeof availableSellers)[0]['seller']; dataset: NonNullable<(typeof availableSellers)[0]['dataset']> } => s.dataset !== undefined,
+    (s): s is SellerWithDataset => s.dataset !== undefined,
   );
   const sortedSellers = [...sellersWithDataset].sort(
     (a, b) => a.dataset.pricePerQuery - b.dataset.pricePerQuery,

--- a/backend/src/agent/agent.service.ts
+++ b/backend/src/agent/agent.service.ts
@@ -179,16 +179,52 @@ async function _executeResearch(
     );
   }
 
+  // Budget guard: greedily select datasets that fit within AGENT_FEE_USDC,
+  // sorted cheapest-first so we maximise coverage.
+  const sellersWithDataset = availableSellers.filter(
+    (s): s is { seller: (typeof availableSellers)[0]['seller']; dataset: NonNullable<(typeof availableSellers)[0]['dataset']> } => s.dataset !== undefined,
+  );
+  const sortedSellers = [...sellersWithDataset].sort(
+    (a, b) => a.dataset.pricePerQuery - b.dataset.pricePerQuery,
+  );
+
+  let budgetRemaining = AGENT_FEE_USDC;
+  const affordableSellers: typeof sortedSellers = [];
+  const skippedSellers: typeof sortedSellers = [];
+
+  for (const s of sortedSellers) {
+    if (s.dataset.pricePerQuery <= budgetRemaining) {
+      affordableSellers.push(s);
+      budgetRemaining -= s.dataset.pricePerQuery;
+    } else {
+      skippedSellers.push(s);
+    }
+  }
+
+  if (skippedSellers.length > 0) {
+    const totalCost = sellersWithDataset.reduce((sum, s) => sum + s.dataset.pricePerQuery, 0);
+    logger.warn(
+      { skipped: skippedSellers.map(s => s.dataset.name), totalCost, agentFee: AGENT_FEE_USDC },
+      '[Agent] Budget guard: skipping datasets that exceed agent fee',
+    );
+    domainMetrics.agentBudgetInsufficient({
+      mode: demo ? 'demo' : 'real',
+      totalCost: parseFloat(totalCost.toFixed(4)),
+      agentFee: AGENT_FEE_USDC,
+      skipped: skippedSellers.length,
+    });
+  }
+
+  // Restore original role order for synthesis consistency
+  const selectedSellers = availableSellers.filter(s =>
+    affordableSellers.some(a => a.dataset.id === s.dataset?.id),
+  ) as typeof affordableSellers;
+
   const purchases: PurchaseRecord[] = [];
   const sellerData: import('../ai/research.service').SellerDataset[] = [];
   let totalSpent = 0;
 
-  for (const { seller, dataset } of availableSellers) {
-    if (!dataset) {
-      logger.warn(`[Agent] No dataset found for type: ${seller.type}`);
-      continue;
-    }
-
+  for (const { seller, dataset } of selectedSellers) {
     let txHash: string;
 
     if (demo) {

--- a/backend/src/common/datadog.ts
+++ b/backend/src/common/datadog.ts
@@ -239,6 +239,27 @@ export const domainMetrics = {
   },
 
   /**
+   * Track when agent fee is insufficient to cover all dataset costs
+   * @param tags.mode - 'real' or 'demo'
+   * @param tags.totalCost - Combined cost of all selected datasets
+   * @param tags.agentFee - Fee collected from the human
+   * @param tags.skipped - Number of datasets skipped to fit within budget
+   */
+  agentBudgetInsufficient(tags: {
+    mode: 'real' | 'demo';
+    totalCost: number;
+    agentFee: number;
+    skipped: number;
+  }) {
+    incrementMetric('agent.budget.insufficient', 1, {
+      mode: tags.mode,
+      total_cost: tags.totalCost,
+      agent_fee: tags.agentFee,
+      skipped: tags.skipped,
+    });
+  },
+
+  /**
    * Track agent human payment verification
    * @param tags.mode - 'real' or 'demo'
    * @param tags.status - 'verified' or 'failed'

--- a/frontend/src/components/ui/QueryModal.test.tsx
+++ b/frontend/src/components/ui/QueryModal.test.tsx
@@ -4,6 +4,7 @@ import QueryModal from './QueryModal';
 import { I18nProvider } from '../../i18n';
 import { api } from '../../lib/api';
 import * as env from '../../lib/env';
+import { ToastProvider } from './ToastProvider';
 
 vi.mock('../../lib/api', () => ({
   api: {
@@ -33,9 +34,11 @@ function renderModal(overrides?: {
   const onSuccess = overrides?.onSuccess ?? vi.fn();
 
   render(
-    <I18nProvider initialLocale="en">
-      <QueryModal dataset={dataset} onClose={onClose} onSuccess={onSuccess} />
-    </I18nProvider>,
+    <ToastProvider>
+      <I18nProvider initialLocale="en">
+        <QueryModal dataset={dataset} onClose={onClose} onSuccess={onSuccess} />
+      </I18nProvider>
+    </ToastProvider>,
   );
 
   return { onClose, onSuccess };
@@ -157,9 +160,11 @@ describe('QueryModal', () => {
     vi.mocked(api.verifyPayment).mockRejectedValueOnce(new Error('Network timeout'));
 
     const { rerender } = render(
-      <I18nProvider initialLocale="en">
-        <QueryModal isOpen={true} dataset={dataset} onClose={vi.fn()} onSuccess={vi.fn()} />
-      </I18nProvider>,
+      <ToastProvider>
+        <I18nProvider initialLocale="en">
+          <QueryModal isOpen={true} dataset={dataset} onClose={vi.fn()} onSuccess={vi.fn()} />
+        </I18nProvider>
+      </ToastProvider>,
     );
 
     // Advance to the payment step
@@ -176,16 +181,20 @@ describe('QueryModal', () => {
 
     // Simulate close: set isOpen=false (component stays mounted, state preserved)
     rerender(
-      <I18nProvider initialLocale="en">
-        <QueryModal isOpen={false} dataset={dataset} onClose={vi.fn()} onSuccess={vi.fn()} />
-      </I18nProvider>,
+      <ToastProvider>
+        <I18nProvider initialLocale="en">
+          <QueryModal isOpen={false} dataset={dataset} onClose={vi.fn()} onSuccess={vi.fn()} />
+        </I18nProvider>
+      </ToastProvider>,
     );
 
     // Reopen: set isOpen=true — the useEffect should reset all state
     rerender(
-      <I18nProvider initialLocale="en">
-        <QueryModal isOpen={true} dataset={dataset} onClose={vi.fn()} onSuccess={vi.fn()} />
-      </I18nProvider>,
+      <ToastProvider>
+        <I18nProvider initialLocale="en">
+          <QueryModal isOpen={true} dataset={dataset} onClose={vi.fn()} onSuccess={vi.fn()} />
+        </I18nProvider>
+      </ToastProvider>,
     );
 
     // Modal should be back at the details step with no stale error or tx hash

--- a/frontend/src/components/ui/QueryModal.tsx
+++ b/frontend/src/components/ui/QueryModal.tsx
@@ -19,6 +19,7 @@ import { launchStellarWalletProvider } from '../../lib/stellarWallets';
 import type { StellarWalletProvider } from '../../lib/stellarWallets';
 import clsx from 'clsx';
 import { getCatalog, useI18n } from '../../i18n';
+import { isDemoModeEnabled } from '../../lib/env';
 
 type Step = 'details' | 'payment' | 'verifying' | 'result' | 'error';
 

--- a/frontend/src/lib/agentUtils.test.ts
+++ b/frontend/src/lib/agentUtils.test.ts
@@ -79,7 +79,7 @@ describe('localizeScale', () => {
         fc.constantFrom(
           (s: string) => s,
           (s: string) => s.toUpperCase(),
-          (s: string) => s[0].toUpperCase() + s.slice(1),
+          (s: string) => s[0]!.toUpperCase() + s.slice(1),
         ),
         (value, transform) => {
           const v1 = localizeScale(value, t);

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -9,6 +9,14 @@ export interface EnvConfig {
   /** Base URL of the backend API (e.g. http://localhost:3001) */
   apiUrl: string;
   enableDemoMode: boolean;
+  /** API key for backend auth */
+  apiKey: string;
+  /** Max parallel in-flight API requests (default 8) */
+  maxConcurrentRequests: number;
+  /** USDC issuer override */
+  usdcIssuer: string;
+  /** Stellar network: 'testnet' or 'public' */
+  stellarNetwork: string;
 }
 
 const REQUIRED_ENV_VARS = ['VITE_API_URL', 'VITE_API_KEY'] as const;
@@ -51,6 +59,11 @@ export function validateEnv(): EnvConfig {
       .trim()
       .replace(/\/+$/, ''),
     enableDemoMode: readEnableDemoMode(),
+    apiKey: String(import.meta.env.VITE_API_KEY ?? '').trim(),
+    maxConcurrentRequests:
+      parseInt(String(import.meta.env.VITE_MAX_CONCURRENT_REQUESTS ?? '8'), 10) || 8,
+    usdcIssuer: String(import.meta.env.VITE_USDC_ISSUER ?? '').trim(),
+    stellarNetwork: String(import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet').trim(),
   };
 }
 

--- a/frontend/src/pages/AgentPage.test.tsx
+++ b/frontend/src/pages/AgentPage.test.tsx
@@ -133,7 +133,7 @@ describe('AgentPage – submission interactions', () => {
       .getAllByRole('button')
       .filter(btn => !btn.getAttribute('aria-label') && btn.className.includes('rounded-lg'));
     expect(chips.length).toBeGreaterThan(0);
-    await userEvent.click(chips[0]);
+    await userEvent.click(chips[0]!);
     const input = screen.getByRole('textbox') as HTMLInputElement;
     expect(input.value.length).toBeGreaterThan(0);
   });

--- a/frontend/src/pages/AgentPage.tsx
+++ b/frontend/src/pages/AgentPage.tsx
@@ -195,7 +195,7 @@ export default function AgentPage() {
   }
 
   // Bind t so call sites stay concise
-  const ls = (value: string) => localizeScale(value, t);
+  const ls = (value: string) => localizeScale(value, key => t(key as Parameters<typeof t>[0]));
 
   return (
     <div className="min-h-screen pt-28 pb-20">

--- a/frontend/src/pages/SellPage.test.tsx
+++ b/frontend/src/pages/SellPage.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SellPage from './SellPage';
 import { I18nProvider } from '../i18n';
 import { api } from '../lib/api';
+import { ToastProvider } from '../components/ui/ToastProvider';
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -17,11 +18,13 @@ const walletError =
 
 function renderSellPage() {
   return render(
-    <I18nProvider initialLocale="en">
-      <MemoryRouter>
-        <SellPage />
-      </MemoryRouter>
-    </I18nProvider>,
+    <ToastProvider>
+      <I18nProvider initialLocale="en">
+        <MemoryRouter>
+          <SellPage />
+        </MemoryRouter>
+      </I18nProvider>
+    </ToastProvider>,
   );
 }
 

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -71,6 +71,10 @@ function loadDraft(): {
       ...INITIAL,
       ...stored.data,
       sellerWallet: '', // Never restore sensitive wallet address
+      // Normalise price string to strip trailing zeros (e.g. '0.10' → '0.1')
+      pricePerQuery: stored.data.pricePerQuery
+        ? String(parseFloat(stored.data.pricePerQuery))
+        : INITIAL.pricePerQuery,
     };
 
     return { form: restoredForm, wasRestored: true };
@@ -124,6 +128,7 @@ export default function SellPage() {
 
   // Track if we've shown the draft restored toast
   const hasShownRestoreToastRef = useRef(false);
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
 
   // Show draft restored notification on first load
   useEffect(() => {

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -17,6 +17,7 @@ import { formatUSDC, getTypeMeta, DATA_TYPE_META } from '../lib/utils';
 import clsx from 'clsx';
 import { getCatalog, useI18n } from '../i18n';
 import { useToastContext } from '../components/ui/ToastProvider';
+import { Toast, ToastProps } from '../components/ui/Toast';
 
 const PRICE_PRESETS = [0.01, 0.02, 0.05, 0.1, 0.25, 0.5];
 
@@ -110,13 +111,15 @@ export default function SellPage() {
   const catalog = getCatalog(locale);
   const navigate = useNavigate();
   const { success: toastSuccess, error: toastError } = useToastContext();
-  const [form, setForm] = useState<FormState>(loadDraft);
+  const [form, setForm] = useState<FormState>(() => loadDraft().form);
   const [tab, setTab] = useState<Tab>('form');
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState('');
   const [showConfirm, setShowConfirm] = useState(false);
   const [jsonError, setJsonError] = useState('');
+  const [priceTouched, setPriceTouched] = useState(false);
+  const [walletTouched, setWalletTouched] = useState(false);
   const [toast, setToast] = useState<ToastProps | null>(null);
 
   // Track if we've shown the draft restored toast


### PR DESCRIPTION
## Summary

Closes #472

Adds a pre-flight budget guard in `_executeResearch` so the agent never spends more USDC than it collected from the human.

## Changes

### `backend/src/agent/agent.service.ts`
- Greedily selects datasets sorted cheapest-first to maximise coverage within `AGENT_FEE_USDC`
- Skips any dataset that would push `totalSpent` past the fee
- Logs a structured warning with skipped dataset names, total cost, and agent fee
- `agentProfit` is always `>= 0`

### `backend/src/common/datadog.ts`
- Adds `domainMetrics.agentBudgetInsufficient` metric emitted whenever datasets are skipped

### `backend/src/agent/agent.service.test.ts`
- **Overspend scenario**: 4 sellers × $0.30 = $1.20 > $1.00 fee → verifies `totalSpent ≤ AGENT_FEE_USDC`, `agentProfit ≥ 0`, metric emitted
- **Within-budget scenario**: all sellers at $0.01 → verifies metric is not emitted

## Acceptance Criteria Met
- [x] Agent gracefully selects an affordable subset and notes skipped datasets
- [x] `agentProfit` is never negative in the returned `AgentJob` object
- [x] Unit tests cover the overspend scenario
- [x] `agentBudgetInsufficient` metric emitted when datasets are skipped