### PR TITLE
Feature/multi token escrow

### DIFF
--- a/backend/src/agent/agent.wallet.ts
+++ b/backend/src/agent/agent.wallet.ts
@@ -4,6 +4,7 @@ import {
   SOROBAN_RPC_URL,
   USDC_ISSUER,
   getNetworkPassphrase,
+  getTokenByCode,
 } from '../lib/stellar.config';
 import { logger } from '../lib/logger';
 
@@ -18,6 +19,7 @@ export interface SendPaymentParams {
   destinationAddress: string;
   amount: string; // string to match Stellar SDK precision
   memo?: string;
+  tokenCode?: string; // defaults to USDC
 }
 
 export interface SendPaymentResult {
@@ -25,37 +27,62 @@ export interface SendPaymentResult {
   from: string;
   to: string;
   amount: string;
+  tokenCode: string;
 }
 
 /**
- * Sends USDC from the agent's own wallet to a data seller.
+ * Sends a token payment from the agent's own wallet to a data seller.
+ * Supports USDC, EURC, or XLM (native).
  * Requires AGENT_WALLET_SECRET in env.
  */
-export async function sendUsdcPayment(params: SendPaymentParams): Promise<SendPaymentResult> {
+export async function sendTokenPayment(params: SendPaymentParams): Promise<SendPaymentResult> {
   const secret = process.env.AGENT_WALLET_SECRET;
   if (!secret) {
     throw new Error('AGENT_WALLET_SECRET not configured — agent cannot send payments');
   }
 
+  const tokenCode = params.tokenCode || 'USDC';
+  const token = getTokenByCode(tokenCode);
+  if (!token) {
+    throw new Error(`Unsupported token: ${tokenCode}`);
+  }
+
   const keypair = StellarSdk.Keypair.fromSecret(secret);
   const account = await server.loadAccount(keypair.publicKey());
 
-  const usdcBal = account.balances.find(b => {
-    if (b.asset_type === 'native') return false;
-    const bal = b as { asset_code: string; asset_issuer: string };
-    return bal.asset_code === 'USDC' && bal.asset_issuer === USDC_ISSUER;
-  }) as { balance: string } | undefined;
+  // For XLM (native), just check native balance; for tokens, check trustline
+  if (tokenCode === 'XLM') {
+    const nativeBal = account.balances.find(b => b.asset_type === 'native');
+    if (!nativeBal || parseFloat(nativeBal.balance) < parseFloat(params.amount)) {
+      throw new Error(
+        `Insufficient XLM balance: need ${params.amount} XLM, have ${nativeBal?.balance || '0'} XLM`,
+      );
+    }
+  } else {
+    // For USDC/EURC
+    const tokenBal = account.balances.find(b => {
+      if (b.asset_type === 'native') return false;
+      const bal = b as { asset_code: string; asset_issuer: string };
+      return bal.asset_code === tokenCode && bal.asset_issuer === token.issuer;
+    }) as { balance: string } | undefined;
 
-  if (!usdcBal) {
-    throw new Error('Agent wallet has no USDC trustline — cannot send payment');
-  }
-  if (parseFloat(usdcBal.balance) < parseFloat(params.amount)) {
-    throw new Error(
-      `Insufficient USDC balance: need ${params.amount} USDC, have ${usdcBal.balance} USDC`,
-    );
+    if (!tokenBal) {
+      throw new Error(`Agent wallet has no ${tokenCode} trustline — cannot send payment`);
+    }
+    if (parseFloat(tokenBal.balance) < parseFloat(params.amount)) {
+      throw new Error(
+        `Insufficient ${tokenCode} balance: need ${params.amount} ${tokenCode}, have ${tokenBal.balance} ${tokenCode}`,
+      );
+    }
   }
 
-  const usdc = new StellarSdk.Asset('USDC', USDC_ISSUER);
+  // Build asset object
+  let asset: StellarSdk.Asset;
+  if (tokenCode === 'XLM') {
+    asset = StellarSdk.Asset.native();
+  } else {
+    asset = new StellarSdk.Asset(tokenCode, token.issuer!);
+  }
 
   const txBuilder = new StellarSdk.TransactionBuilder(account, {
     fee: StellarSdk.BASE_FEE,
@@ -63,7 +90,7 @@ export async function sendUsdcPayment(params: SendPaymentParams): Promise<SendPa
   }).addOperation(
     StellarSdk.Operation.payment({
       destination: params.destinationAddress,
-      asset: usdc,
+      asset,
       amount: params.amount,
     }),
   );
@@ -81,7 +108,15 @@ export async function sendUsdcPayment(params: SendPaymentParams): Promise<SendPa
     from: keypair.publicKey(),
     to: params.destinationAddress,
     amount: params.amount,
+    tokenCode,
   };
+}
+
+/**
+ * Deprecated: Use sendTokenPayment instead
+ */
+export async function sendUsdcPayment(params: SendPaymentParams): Promise<SendPaymentResult> {
+  return sendTokenPayment({ ...params, tokenCode: 'USDC' });
 }
 
 /**
@@ -161,7 +196,7 @@ export function validateAgentWallet(): void {
   if (!rawSecret) {
     throw new Error(
       '[AgentWallet] AGENT_WALLET_SECRET is not set. ' +
-        'The agent wallet cannot sign transactions.',
+      'The agent wallet cannot sign transactions.',
     );
   }
 
@@ -173,7 +208,7 @@ export function validateAgentWallet(): void {
     // Do NOT include the caught error in this throw — it may echo key material.
     throw new Error(
       '[AgentWallet] AGENT_WALLET_SECRET is set but is not a valid Stellar secret key. ' +
-        'Check the value in your environment configuration.',
+      'Check the value in your environment configuration.',
     );
   }
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -17,6 +17,7 @@ export const datasets = pgTable(
     description: text('description').notNull(),
     type: text('type').notNull(),
     pricePerQuery: numeric('price_per_query').notNull(),
+    paymentToken: text('payment_token').notNull().default('USDC'), // USDC | EURC | XLM
     sellerWallet: text('seller_wallet').notNull(),
     data: text('data').notNull().default('{}'),
     queriesServed: integer('queries_served').notNull().default(0),
@@ -35,6 +36,7 @@ export const transactions = pgTable('transactions', {
   datasetId: text('dataset_id').notNull(),
   txHash: text('tx_hash').notNull().unique(),
   amount: numeric('amount').notNull(),
+  paymentToken: text('payment_token').notNull().default('USDC'), // Track which token was used
   buyerQuery: text('buyer_query'),
   aiSummary: text('ai_summary'),
   timestamp: text('timestamp').notNull(),
@@ -63,6 +65,7 @@ export const datasetsSqlite = sqliteTable(
     description: sqliteText('description').notNull(),
     type: sqliteText('type').notNull(),
     pricePerQuery: sqliteText('price_per_query').notNull(),
+    paymentToken: sqliteText('payment_token').notNull().default('USDC'),
     sellerWallet: sqliteText('seller_wallet').notNull(),
     data: sqliteText('data').notNull().default('{}'),
     queriesServed: sqliteInteger('queries_served').notNull().default(0),
@@ -81,6 +84,7 @@ export const transactionsSqlite = sqliteTable('transactions', {
   datasetId: sqliteText('dataset_id').notNull(),
   txHash: sqliteText('tx_hash').notNull().unique(),
   amount: sqliteText('amount').notNull(),
+  paymentToken: sqliteText('payment_token').notNull().default('USDC'),
   buyerQuery: sqliteText('buyer_query'),
   aiSummary: sqliteText('ai_summary'),
   timestamp: sqliteText('timestamp').notNull(),

--- a/backend/src/lib/stellar.config.ts
+++ b/backend/src/lib/stellar.config.ts
@@ -14,8 +14,40 @@ export const SOROBAN_RPC_URL =
     ? 'https://soroban.stellar.org'
     : 'https://soroban-testnet.stellar.org');
 
+// ── Multi-token support ──────────────────────────────────────────────────────
+
+export interface StellarToken {
+  code: 'USDC' | 'EURC' | 'XLM';
+  issuer?: string; // undefined for XLM (native)
+  address?: string; // Soroban contract address
+}
+
 export const USDC_ISSUER =
   process.env.USDC_ISSUER ?? 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'; // default testnet issuer
+
+export const EURC_ISSUER =
+  process.env.EURC_ISSUER ?? 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'; // testnet: same publisher as USDC
+
+export const SUPPORTED_TOKENS: Record<string, StellarToken> = {
+  USDC: {
+    code: 'USDC',
+    issuer: USDC_ISSUER,
+  },
+  EURC: {
+    code: 'EURC',
+    issuer: EURC_ISSUER,
+  },
+  XLM: {
+    code: 'XLM',
+    // native, no issuer
+  },
+};
+
+export const DEFAULT_TOKEN_CODE = 'USDC';
+
+export function getTokenByCode(code: string): StellarToken | null {
+  return SUPPORTED_TOKENS[code] || null;
+}
 
 export const getNetworkPassphrase = () => {
   if (STELLAR_NETWORK === 'mainnet') {

--- a/backend/src/payments/payments.router.ts
+++ b/backend/src/payments/payments.router.ts
@@ -174,12 +174,15 @@ paymentsRouter.post('/query/:id', async (req: Request, res: Response) => {
   const memo = `haz-${req.params.id.slice(0, 8)}-${timestamp}`;
 
   const transactionId = `tx-${uuidv4()}`;
+  const tokenCode = dataset.paymentToken || 'USDC';
+
   await addTransaction({
     id: transactionId,
     datasetId: dataset.id,
     txHash: '', // Not yet known
     memo,
     amount: dataset.pricePerQuery,
+    paymentToken: tokenCode,
     status: 'pending',
     deliveryStatus: 'pending',
     timestamp: new Date().toISOString(),
@@ -197,13 +200,13 @@ paymentsRouter.post('/query/:id', async (req: Request, res: Response) => {
     payment: {
       paymentAddress: process.env.ESCROW_WALLET || dataset.sellerWallet,
       amount: dataset.pricePerQuery,
-      currency: 'USDC',
+      currency: tokenCode,
       network: 'Stellar Testnet',
       memo,
       expiresIn: 300, // 5 minutes
       instructions: [
         `1. Open your Stellar wallet (Lobstr, StellarX, or testnet faucet)`,
-        `2. Send exactly ${dataset.pricePerQuery} USDC to the address above`,
+        `2. Send exactly ${dataset.pricePerQuery} ${tokenCode} to the address above`,
         `3. Include memo: ${memo}`,
         `4. Submit the transaction hash below to receive your data`,
       ],

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -229,6 +229,7 @@ export async function processPayment(params: {
 
   const transactionId = existing?.id || `tx-${uuidv4()}`;
   const destinationAddress = process.env.ESCROW_WALLET || dataset.sellerWallet;
+  const tokenCode = dataset.paymentToken || 'USDC';
 
   transactionEventEmitter.updateTransactionStatus(transactionId, dataset.id, 'verifying', {
     amount: dataset.pricePerQuery.toString(),
@@ -239,6 +240,7 @@ export async function processPayment(params: {
     txHash,
     expectedAmount: dataset.pricePerQuery,
     destinationAddress,
+    tokenCode,
   });
 
   if (!verification.valid) {
@@ -377,7 +379,7 @@ export async function retryFailedSellerNotifications(): Promise<void> {
         // Exhausted retries — surface a durable alert so an operator can investigate
         console.error(
           `[Escrow] Seller notification permanently failed after ${MAX_SELLER_NOTIFICATION_ATTEMPTS} attempts ` +
-            `txHash=${tx.txHash} dataset=${tx.datasetId} seller=${tx.datasetId}`,
+          `txHash=${tx.txHash} dataset=${tx.datasetId} seller=${tx.datasetId}`,
         );
         Sentry.captureMessage(`Seller notification permanently failed: txHash=${tx.txHash}`, {
           level: 'error',
@@ -419,7 +421,7 @@ export async function retryFailedSellerNotifications(): Promise<void> {
         });
         console.error(
           `[Escrow] Seller notification retry ${attempts}/${MAX_SELLER_NOTIFICATION_ATTEMPTS} failed ` +
-            `txHash=${tx.txHash}: ${errMsg}`,
+          `txHash=${tx.txHash}: ${errMsg}`,
         );
       }
     }),

--- a/backend/src/payments/stellar.service.ts
+++ b/backend/src/payments/stellar.service.ts
@@ -1,7 +1,7 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { getCircuitBreaker } from '../common/circuit-breaker';
 import { domainMetrics } from '../common/datadog';
-import { HORIZON_URL, USDC_ISSUER } from '../lib/stellar.config';
+import { HORIZON_URL, USDC_ISSUER, EURC_ISSUER, getTokenByCode } from '../lib/stellar.config';
 import { logger } from '../lib/logger';
 
 const server = new StellarSdk.Horizon.Server(HORIZON_URL);
@@ -18,6 +18,7 @@ interface VerifyParams {
   txHash: string;
   expectedAmount: number;
   destinationAddress: string;
+  tokenCode: string; // USDC | EURC | XLM
 }
 
 interface VerifyResult {
@@ -53,7 +54,7 @@ export class StellarTimeoutError extends Error {
   constructor(timeoutMs: number) {
     super(
       `Stellar Horizon did not respond within ${timeoutMs / 1000} seconds. ` +
-        'The payment network may be congested — please try again shortly.',
+      'The payment network may be congested — please try again shortly.',
     );
     this.name = 'StellarTimeoutError';
   }
@@ -91,8 +92,18 @@ async function withHorizonRetry<T>(fn: () => Promise<T>): Promise<T> {
   throw new Error('unreachable');
 }
 
+function getTokenIssuer(tokenCode: string): string | null {
+  const token = getTokenByCode(tokenCode);
+  return token?.issuer || null;
+}
+
 export async function verifyStellarPayment(params: VerifyParams): Promise<VerifyResult> {
-  const { txHash, expectedAmount, destinationAddress } = params;
+  const { txHash, expectedAmount, destinationAddress, tokenCode } = params;
+
+  const expectedIssuer = getTokenIssuer(tokenCode);
+  if (!getTokenByCode(tokenCode)) {
+    return { valid: false, reason: `Unsupported token: ${tokenCode}` };
+  }
 
   try {
     const [tx, ops] = await withStellarTimeout(
@@ -124,28 +135,34 @@ export async function verifyStellarPayment(params: VerifyParams): Promise<Verify
       return { valid: false, reason: 'No payment to escrow address found in transaction' };
     }
 
-    // Find USDC payment — must match both asset code and issuer to prevent XLM/fake-USDC substitution
-    const usdcOps = paymentOps.filter(op => {
+    // For XLM (native), check asset_type === 'native'
+    // For USDC/EURC (tokens), match both asset_code and issuer
+    const matchingOps = paymentOps.filter(op => {
       const payOp = op as StellarSdk.Horizon.ServerApi.PaymentOperationRecord;
-      return payOp.asset_code === 'USDC' && payOp.asset_issuer === USDC_ISSUER;
+
+      if (tokenCode === 'XLM') {
+        return payOp.asset_type === 'native';
+      }
+
+      return payOp.asset_code === tokenCode && payOp.asset_issuer === expectedIssuer;
     });
 
-    if (usdcOps.length === 0) {
+    if (matchingOps.length === 0) {
       domainMetrics.stellarPaymentVerified({
         datasetType: 'unknown',
         mode: 'real',
         status: 'failed',
-        reason: 'no_usdc_found',
+        reason: `no_${tokenCode.toLowerCase()}_found`,
       });
       return {
         valid: false,
-        reason: 'No USDC payment found — ensure you sent USDC on Stellar testnet',
+        reason: `No ${tokenCode} payment found — ensure you sent ${tokenCode} on Stellar testnet`,
       };
     }
 
-    const payOp = usdcOps[0] as StellarSdk.Horizon.ServerApi.PaymentOperationRecord;
+    const payOp = matchingOps[0] as StellarSdk.Horizon.ServerApi.PaymentOperationRecord;
     const actualAmount = parseFloat(payOp.amount);
-    const tolerance = 0.001; // 0.001 USDC tolerance
+    const tolerance = 0.001; // 0.001 token tolerance
 
     if (Math.abs(actualAmount - expectedAmount) > tolerance) {
       domainMetrics.stellarPaymentVerified({
@@ -156,7 +173,7 @@ export async function verifyStellarPayment(params: VerifyParams): Promise<Verify
       });
       return {
         valid: false,
-        reason: `Amount mismatch: expected ${expectedAmount} USDC, received ${actualAmount} USDC`,
+        reason: `Amount mismatch: expected ${expectedAmount} ${tokenCode}, received ${actualAmount} ${tokenCode}`,
         actualAmount,
       };
     }

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -28,6 +28,7 @@ interface FormState {
   description: string;
   type: string;
   pricePerQuery: string;
+  paymentToken: 'USDC' | 'EURC' | 'XLM';
   sellerWallet: string;
   dataText: string;
 }
@@ -37,6 +38,7 @@ const INITIAL: FormState = {
   description: '',
   type: 'whale-wallets',
   pricePerQuery: '0.05',
+  paymentToken: 'USDC',
   sellerWallet: '',
   dataText: '',
 };
@@ -229,6 +231,7 @@ export default function SellPage() {
         description: form.description.trim(),
         type: form.type,
         pricePerQuery: parseFloat(form.pricePerQuery),
+        paymentToken: form.paymentToken,
         sellerWallet: form.sellerWallet.trim(),
         data: JSON.parse(form.dataText),
       });
@@ -348,8 +351,8 @@ export default function SellPage() {
                   />
                 </div>
 
-                {/* Type + Price row */}
-                <div className="grid grid-cols-2 gap-4">
+                {/* Type + Price + Token row */}
+                <div className="grid grid-cols-3 gap-4">
                   <div>
                     <label className="text-sm font-body font-medium text-foreground-muted mb-2 flex items-center gap-2">
                       <Zap className="w-4 h-4 text-gold" />
@@ -393,9 +396,23 @@ export default function SellPage() {
                       </p>
                     )}
                   </div>
-                </div>
 
-                {/* Price presets */}
+                  <div>
+                    <label className="text-sm font-body font-medium text-foreground-muted mb-2 flex items-center gap-2">
+                      <DollarSign className="w-4 h-4 text-gold" />
+                      {t('sell.form.paymentToken')} <span className="text-red-400">*</span>
+                    </label>
+                    <select
+                      value={form.paymentToken}
+                      onChange={set('paymentToken') as any}
+                      className="w-full bg-void/60 border border-border/60 rounded-xl px-4 py-3 text-sm font-body text-foreground focus:outline-none focus:border-gold/50 transition-colors"
+                    >
+                      <option value="USDC">USDC</option>
+                      <option value="EURC">EURC</option>
+                      <option value="XLM">XLM</option>
+                    </select>
+                  </div>
+                </div>
                 <div>
                   <p className="text-xs text-muted-2 font-body mb-2">
                     {t('sell.form.quickPricePresets')}
@@ -553,7 +570,7 @@ export default function SellPage() {
                         You are about to list{' '}
                         <span className="text-foreground font-medium">{form.name}</span> at{' '}
                         <span className="text-gold font-semibold">
-                          ${formatUSDC(Number(form.pricePerQuery), locale)} USDC
+                          ${formatUSDC(Number(form.pricePerQuery), locale)} {form.paymentToken}
                         </span>{' '}
                         per query. This action cannot be undone.
                       </p>
@@ -591,7 +608,7 @@ export default function SellPage() {
                     <div className="text-right">
                       <p className="text-xs text-muted-2 mb-0.5">{t('common.units.perQuery')}</p>
                       <p className="font-display font-bold text-xl text-gold">
-                        ${formatUSDC(Number(form.pricePerQuery || '0'), locale)}
+                        ${formatUSDC(Number(form.pricePerQuery || '0'), locale)} {form.paymentToken}
                       </p>
                     </div>
                   </div>
@@ -613,6 +630,7 @@ export default function SellPage() {
                   <div className="w-full py-3 rounded-xl border border-border-gold/30 text-gold text-sm font-body font-semibold text-center">
                     {t('sell.preview.buyLabel', {
                       price: formatUSDC(Number(form.pricePerQuery || '0'), locale),
+                      token: form.paymentToken,
                     })}
                   </div>
                 </div>


### PR DESCRIPTION
# Multi-Token Escrow Support
# Closes #471
## Summary

Extends the Hazina escrow system from USDC-only to supporting multiple Stellar tokens: **USDC**, **EURC**, and **XLM** (native). Sellers can now choose which token they want to receive when listing a dataset, and the payment pipeline validates and processes transactions in the selected token end-to-end.

## Changes

### Schema (`backend/src/db/schema.ts`)
- Added `paymentToken` column to `datasets` and `transactions` tables (both Postgres and SQLite), defaulting to `USDC` for backward compatibility.

### Stellar Config (`backend/src/lib/stellar.config.ts`)
- Introduced `StellarToken` interface and `SUPPORTED_TOKENS` registry mapping token codes to their issuers.
- Added `EURC_ISSUER` environment variable support.
- Added `getTokenByCode()` helper for token lookup.

### Agent Wallet (`backend/src/agent/agent.wallet.ts`)
- Generalized `sendUsdcPayment` into `sendTokenPayment` supporting USDC, EURC, and XLM.
- XLM uses native asset; USDC/EURC use trustline-based balance checks.
- Kept `sendUsdcPayment` as a deprecated wrapper for backward compatibility.

### Payment Verification (`backend/src/payments/stellar.service.ts`)
- `verifyStellarPayment` now accepts a `tokenCode` parameter.
- Validates on-chain payments against the correct asset type and issuer (native for XLM, issued asset for USDC/EURC).
- Error messages and metrics now reflect the specific token.

### Payment Processing (`backend/src/payments/payments.service.ts`, `payments.router.ts`)
- Reads `paymentToken` from the dataset configuration.
- Passes token code through to verification and transaction records.
- Payment instructions returned to buyers now display the correct currency.

### Frontend (`frontend/src/pages/SellPage.tsx`)
- Added a token selector dropdown (USDC / EURC / XLM) to the dataset listing form.
- Price preview and confirmation dialog now display the selected token.

## Test Plan

- [x] Create a dataset listing with each token type (USDC, EURC, XLM) and verify it persists correctly
- [x] Verify payment instructions show the correct token and amount for each type
- [x] Submit a test USDC payment and confirm verification passes
- [x] Submit a test XLM (native) payment and confirm verification handles the native asset correctly
- [x] Verify backward compatibility: existing USDC-only datasets still work without migration
- [x] Confirm the frontend token selector renders correctly and submits the chosen token
- [x] Check that `sendTokenPayment` correctly validates balances/trustlines for each token type
- [x] Verify that unsupported token codes are rejected with a clear error
