### PR TITLE
fix: close TOCTOU race in POST /verify/:id

### DIFF
--- a/backend/src/payments/payments.router.ts
+++ b/backend/src/payments/payments.router.ts
@@ -17,6 +17,7 @@ import {
   updateDataset,
   addTransaction,
   getUnpaidTransactions,
+  reserveTxHash,
 } from '../common/storage';
 import { validateBody } from '../common/validate';
 import { sellerShare, platformFee as computePlatformFee } from '../common/constants';
@@ -283,6 +284,7 @@ paymentsRouter.post(
       return res.status(400).json({ error: 'Escrow already processed' });
     }
 
+    const releaseReservation = reserveTxHash(txHash);
     try {
       const result = await processPayment({
         txHash,
@@ -332,6 +334,8 @@ paymentsRouter.post(
       }
       console.error('[Verify] Unexpected error processing payment:', err);
       return res.status(500).json({ error: 'Payment verification failed — please try again' });
+    } finally {
+      releaseReservation();
     }
   },
 );


### PR DESCRIPTION
## Summary

Wires up `reserveTxHash()` in the buyer-facing `POST /verify/:id` handler — the same pattern already used in `agent.service.ts`.

## Root cause

The handler checked `txHashUsed()` before the slow async `processPayment()` call (Stellar Horizon network request) but never reserved the hash in `pendingTxHashes` during that window. Two concurrent requests with the same `txHash` could both pass the check, both verify the same on-chain payment, and both deliver the dataset + trigger a seller payout.

## Fix

```ts
const releaseReservation = reserveTxHash(txHash); // ← added
try {
  const result = await processPayment({ txHash, ... });
  // ...
} catch (err) {
  // ...
} finally {
  releaseReservation(); // ← added
}
```

Close #488