### PR TITLE
fix(datasets): remove unverified POST /:id/ratings route shadowing verified handler

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -47,6 +47,7 @@
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@vitest/coverage-v8": "^1.2.0",
+        "drizzle-kit": "^0.21.4",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "supertest": "^6.3.3",
@@ -411,6 +412,833 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2573,6 +3401,23 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
+    "node_modules/cli-color": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
+      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.64",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2609,6 +3454,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/component-emitter": {
@@ -2721,6 +3576,20 @@
       "resolved": "https://registry.npmjs.org/crypto-randomuuid/-/crypto-randomuuid-1.0.0.tgz",
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA==",
       "license": "MIT"
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
@@ -2987,6 +3856,18 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==",
+      "dev": true,
+      "dependencies": {
+        "heap": ">= 0.2.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3022,6 +3903,39 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dreamopt": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
+      "integrity": "sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==",
+      "dev": true,
+      "dependencies": {
+        "wordwrap": ">=0.0.2"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/drizzle-kit": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.21.4.tgz",
+      "integrity": "sha512-Nxcc1ONJLRgbhmR+azxjNF9Ly9privNLEIgW53c92whb4xp8jZLH1kMCh/54ci1mTMuYxPdOukqLwJ8wRudNwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "commander": "^9.4.1",
+        "env-paths": "^3.0.0",
+        "esbuild": "^0.19.7",
+        "esbuild-register": "^3.5.0",
+        "glob": "^8.1.0",
+        "hanji": "^0.0.5",
+        "json-diff": "0.9.0",
+        "zod": "^3.20.2"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
       }
     },
     "node_modules/drizzle-orm": {
@@ -3182,6 +4096,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3232,6 +4159,114 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
+    "node_modules/esbuild-register": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
+      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.12 <1"
       }
     },
     "node_modules/escape-html": {
@@ -3410,6 +4445,22 @@
         "node": "*"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -3490,6 +4541,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/event-target-shim": {
@@ -3610,6 +4672,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
     },
     "node_modules/fast-copy": {
       "version": "4.0.3",
@@ -4042,11 +5114,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -4059,6 +5165,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -4116,6 +5235,17 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hanji": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/hanji/-/hanji-0.0.5.tgz",
+      "integrity": "sha512-Abxw1Lq+TnYiL4BueXqMau222fPSPMFtya8HdpWsz/xVAhifXou71mPh/kY2+08RgFcVccjG3uZHs6K5HAe3zw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash.throttle": "^4.1.1",
+        "sisteransi": "^1.0.5"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4177,6 +5307,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/help-me": {
       "version": "5.0.0",
@@ -4433,6 +5570,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -4587,6 +5731,24 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-diff": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.9.0.tgz",
+      "integrity": "sha512-cVnggDrVkAAA3OvFfHpFEhOnmcsUpleEKq4d4O8sQWWSH40MBrWstKigVB1kGrgLWzuom+7rRdaCsnBD6VyObQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-color": "^2.0.0",
+        "difflib": "~0.2.1",
+        "dreamopt": "~0.8.0"
+      },
+      "bin": {
+        "json-diff": "bin/json-diff.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4936,6 +6098,13 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -4943,6 +6112,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
       }
     },
     "node_modules/magic-string": {
@@ -5006,6 +6185,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/merge-descriptors": {
@@ -5200,6 +6399,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/node-abi": {
       "version": "3.92.0",
@@ -6138,6 +7344,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -6611,6 +7827,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7073,6 +8296,20 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7394,6 +8631,13 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7826,6 +9070,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/backend/src/common/auth.middleware.ts
+++ b/backend/src/common/auth.middleware.ts
@@ -193,6 +193,49 @@ export function requireSellerMutationAuth(req: Request, res: Response, next: Nex
   next();
 }
 
+/**
+ * For GET /:sellerWallet — accepts the shared API key (admin, no wallet scope
+ * restriction) OR a seller JWT scoped to the wallet in req.params.sellerWallet.
+ * In non-production, skips auth when neither API_KEY nor SELLER_JWT_SECRET is set.
+ */
+export function requireSellerReadAuth(req: Request, res: Response, next: NextFunction) {
+  const apiKey = process.env.API_KEY;
+  const secret = process.env.SELLER_JWT_SECRET;
+
+  if (!apiKey && !secret) {
+    if (process.env.NODE_ENV === 'production') {
+      return res
+        .status(503)
+        .json({ error: 'Server misconfigured: API_KEY or SELLER_JWT_SECRET must be set' });
+    }
+    logger.warn('[auth] API_KEY and SELLER_JWT_SECRET not set — skipping read auth in non-production');
+    return next();
+  }
+
+  const token = getBearerToken(req.headers.authorization);
+  if (!token) {
+    return res.status(401).json({ error: 'Authorization header missing or not Bearer' });
+  }
+
+  // Shared API key — admin, can read any seller's data.
+  if (apiKey && token === apiKey) return next();
+
+  // Seller JWT — must be scoped to the wallet in the route param.
+  if (!secret) {
+    return res.status(503).json({ error: 'Server misconfigured: SELLER_JWT_SECRET is not set' });
+  }
+  const claims = verifySellerJwt(token, secret);
+  if (!claims) {
+    return res.status(401).json({ error: 'Invalid or expired seller token' });
+  }
+  const paramWallet = req.params['sellerWallet'];
+  if (paramWallet && claims.sellerWallet !== paramWallet) {
+    return res.status(403).json({ error: 'Token wallet does not match requested seller' });
+  }
+  req.sellerAuth = claims;
+  next();
+}
+
 /** Protects seller dashboard reads with a non-optional, expiring HS256 JWT. */
 export function requireSellerJwt(req: Request, res: Response, next: NextFunction) {
   const secret = process.env.SELLER_JWT_SECRET;

--- a/backend/src/datasets/datasets.router.test.ts
+++ b/backend/src/datasets/datasets.router.test.ts
@@ -11,8 +11,10 @@ vi.mock('../common/storage', () => ({
   getAllDatasets: vi.fn(),
   getDataset: vi.fn(),
   addDataset: vi.fn(),
+  updateDataset: vi.fn(),
   getTransactions: vi.fn(),
   getTransactionsCount: vi.fn(),
+  getTransactionByHash: vi.fn(),
 }));
 
 const { mockIsValidStellarAddress } = vi.hoisted(() => ({
@@ -28,8 +30,10 @@ import {
   getAllDatasets,
   getDataset,
   addDataset,
+  updateDataset,
   getTransactions,
   getTransactionsCount,
+  getTransactionByHash,
 } from '../common/storage';
 import type { Dataset, Transaction } from '../common/storage';
 
@@ -410,5 +414,207 @@ describe('wallet address validation on POST /api/datasets', () => {
       .send(validDatasetBody);
 
     expect(mockIsValidStellarAddress).toHaveBeenCalledWith(VALID_WALLET);
+  });
+});
+
+// ── POST/GET /:id/ratings ─────────────────────────────────────────────────────
+
+const DATASET_ID = 'ds-rate-me';
+const TX_HASH = 'abc123txhash';
+
+const baseDataset: Dataset = {
+  id: DATASET_ID,
+  name: 'Rateable Dataset',
+  description: 'A dataset with ratings',
+  type: 'sentiment',
+  pricePerQuery: 1,
+  sellerWallet: SELLER_A,
+  data: {},
+  queriesServed: 1,
+  totalEarned: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const deliveredTx: Transaction = {
+  id: 'tx-rate',
+  datasetId: DATASET_ID,
+  txHash: TX_HASH,
+  amount: 1,
+  deliveryStatus: 'delivered',
+  timestamp: '2026-01-05T00:00:00.000Z',
+};
+
+describe('POST /api/v1/datasets/:id/ratings', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = makeApp();
+    vi.mocked(getDataset).mockResolvedValue({ ...baseDataset });
+    vi.mocked(getTransactionByHash).mockResolvedValue(deliveredTx);
+    vi.mocked(updateDataset).mockImplementation(async (_id, updates) => ({
+      ...baseDataset,
+      ...updates,
+    }) as Dataset);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts a valid txHash + score and returns the updated ratings', async () => {
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: TX_HASH, score: 4 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.ratings.reviews).toHaveLength(1);
+    expect(res.body.ratings.reviews[0]).toMatchObject({ txHash: TX_HASH, score: 4 });
+    expect(res.body.ratings.count).toBe(1);
+    expect(res.body.ratings.score).toBe(4);
+  });
+
+  it('stores an optional comment alongside the review', async () => {
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: TX_HASH, score: 5, comment: 'Great dataset!' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.ratings.reviews[0].comment).toBe('Great dataset!');
+  });
+
+  it('returns 400 when txHash is missing (bare score rejected)', async () => {
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ score: 3 });
+
+    expect(res.status).toBe(400);
+    expect(updateDataset).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when score is out of range', async () => {
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: TX_HASH, score: 6 });
+
+    expect(res.status).toBe(400);
+    expect(updateDataset).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the dataset does not exist', async () => {
+    vi.mocked(getDataset).mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .post(`/api/v1/datasets/nonexistent/ratings`)
+      .send({ txHash: TX_HASH, score: 3 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when txHash does not exist', async () => {
+    vi.mocked(getTransactionByHash).mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: 'unknown-hash', score: 3 });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('Invalid transaction hash');
+  });
+
+  it('returns 403 when txHash belongs to a different dataset', async () => {
+    vi.mocked(getTransactionByHash).mockResolvedValue({ ...deliveredTx, datasetId: 'other-ds' });
+
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: TX_HASH, score: 3 });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('Invalid transaction hash');
+  });
+
+  it('returns 403 when delivery is not yet complete', async () => {
+    vi.mocked(getTransactionByHash).mockResolvedValue({ ...deliveredTx, deliveryStatus: 'pending' });
+
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: TX_HASH, score: 3 });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('delivered before rating');
+  });
+
+  it('returns 409 on duplicate txHash (prevents repeat ratings)', async () => {
+    const datasetWithReview: Dataset = {
+      ...baseDataset,
+      ratings: {
+        score: 4,
+        count: 1,
+        reviews: [{ txHash: TX_HASH, score: 4, timestamp: '2026-01-05T00:00:00.000Z' }],
+      },
+    };
+    vi.mocked(getDataset).mockResolvedValue(datasetWithReview);
+
+    const res = await request(app)
+      .post(`/api/v1/datasets/${DATASET_ID}/ratings`)
+      .send({ txHash: TX_HASH, score: 2 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('Duplicate rating');
+    expect(updateDataset).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/v1/datasets/:id/ratings', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = makeApp();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns score, count, and paginated reviews', async () => {
+    const datasetWithReviews: Dataset = {
+      ...baseDataset,
+      ratings: {
+        score: 4.5,
+        count: 2,
+        reviews: [
+          { txHash: 'tx-1', score: 4, timestamp: '2026-01-05T00:00:00.000Z' },
+          { txHash: 'tx-2', score: 5, timestamp: '2026-01-06T00:00:00.000Z' },
+        ],
+      },
+    };
+    vi.mocked(getDataset).mockResolvedValue(datasetWithReviews);
+
+    const res = await request(app).get(`/api/v1/datasets/${DATASET_ID}/ratings`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.score).toBe(4.5);
+    expect(res.body.count).toBe(2);
+    expect(res.body.reviews).toHaveLength(2);
+  });
+
+  it('returns empty reviews for a dataset with no ratings', async () => {
+    vi.mocked(getDataset).mockResolvedValue({ ...baseDataset });
+
+    const res = await request(app).get(`/api/v1/datasets/${DATASET_ID}/ratings`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.score).toBe(0);
+    expect(res.body.count).toBe(0);
+    expect(res.body.reviews).toEqual([]);
+  });
+
+  it('returns 404 when the dataset does not exist', async () => {
+    vi.mocked(getDataset).mockResolvedValue(undefined);
+
+    const res = await request(app).get(`/api/v1/datasets/nonexistent/ratings`);
+
+    expect(res.status).toBe(404);
   });
 });

--- a/backend/src/datasets/datasets.router.ts
+++ b/backend/src/datasets/datasets.router.ts
@@ -521,25 +521,6 @@ datasetsRouter.get('/:id', async (req: Request, res: Response) => {
   return res.json({ success: true, dataset: toDatasetDetail(dataset) });
 });
 
-const ratingSchema = z.object({ score: z.coerce.number().int().min(1).max(5) });
-
-datasetsRouter.post(
-  '/:id/ratings',
-  validateBody(ratingSchema),
-  async (req: Request, res: Response) => {
-    const dataset = await getDataset(req.params.id);
-    if (!dataset) return res.status(404).json({ error: 'Dataset not found' });
-    const { score } = req.body as z.infer<typeof ratingSchema>;
-    const current = dataset.ratings ?? { score: 0, count: 0 };
-    const count = current.count + 1;
-    const average = Number(((current.score * current.count + score) / count).toFixed(2));
-    const updated = await updateDataset(dataset.id, { ratings: { score: average, count } });
-    return res
-      .status(201)
-      .json({ success: true, ratings: updated?.ratings ?? { score: average, count } });
-  },
-);
-
 /**
  * @openapi
  * /api/datasets/{id}/transactions:

--- a/backend/src/webhooks/webhook.router.test.ts
+++ b/backend/src/webhooks/webhook.router.test.ts
@@ -2,8 +2,76 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express, { Express } from 'express';
 import crypto from 'crypto';
+import { Keypair } from '@stellar/stellar-sdk';
 
-// Mock services
+// ── In-memory storage state ────────────────────────────────────────────────
+
+type MockWebhook = {
+  id: string;
+  sellerWallet: string;
+  url: string;
+  secret: string;
+  events: string[];
+  active: boolean;
+  createdAt: string;
+};
+
+type MockTransaction = {
+  id: string;
+  datasetId: string;
+  txHash: string;
+  memo?: string;
+  amount: number;
+  status: string;
+  timestamp: string;
+  buyerQuery?: string;
+  [key: string]: unknown;
+};
+
+let _webhooks: MockWebhook[] = [];
+let _transactions: MockTransaction[] = [];
+
+function resetStore() {
+  _webhooks = [];
+  _transactions = [];
+}
+
+// ── Module mocks ───────────────────────────────────────────────────────────
+
+vi.mock('../common/storage', () => ({
+  addWebhook: vi.fn(async (wh: MockWebhook) => {
+    _webhooks.push(wh);
+  }),
+  getWebhookById: vi.fn(async (id: string) => {
+    return _webhooks.find(w => w.id === id);
+  }),
+  getWebhooksForSeller: vi.fn(async (wallet: string) => {
+    return _webhooks.filter(w => w.sellerWallet === wallet);
+  }),
+  removeWebhook: vi.fn(async (id: string) => {
+    const idx = _webhooks.findIndex(w => w.id === id);
+    if (idx === -1) return false;
+    _webhooks.splice(idx, 1);
+    return true;
+  }),
+  updateWebhook: vi.fn(async (id: string, updates: Partial<MockWebhook>) => {
+    const idx = _webhooks.findIndex(w => w.id === id);
+    if (idx === -1) return undefined;
+    _webhooks[idx] = { ..._webhooks[idx], ...updates };
+    return _webhooks[idx];
+  }),
+  getTransactionByMemo: vi.fn(async (memo: string) => {
+    return _transactions.find(tx => tx.memo === memo);
+  }),
+  addTransaction: vi.fn(async (tx: MockTransaction) => {
+    _transactions.push(tx);
+    return tx;
+  }),
+  writeStore: vi.fn(async () => {}),
+  readStore: vi.fn(async () => ({ datasets: [], transactions: [], webhooks: [], payoutFailures: [] })),
+  invalidateCache: vi.fn(),
+}));
+
 vi.mock('./webhook.service', () => ({
   notifySeller: vi.fn(() => Promise.resolve()),
   dispatchWebhook: vi.fn(() => Promise.resolve()),
@@ -23,64 +91,80 @@ vi.mock('../payments/payments.service', () => ({
   markDeliveryFailure: vi.fn(),
 }));
 
-vi.mock('../common/storage', async () => {
-  const actual = await vi.importActual('../common/storage');
-  let mockTransactions: { memo?: string; [key: string]: unknown }[] = [];
-  return {
-    ...actual,
-    getTransactionByMemo: vi.fn((memo: string) => {
-      return mockTransactions.find(tx => tx.memo === memo);
-    }),
-    addTransaction: vi.fn(async (tx: { memo?: string; [key: string]: unknown }) => {
-      mockTransactions.push(tx);
-      return tx;
-    }),
-    writeStore: actual.writeStore,
-    readStore: actual.readStore,
-    _clearMockTransactions: () => {
-      mockTransactions = [];
-    },
-  };
-});
+vi.mock('../common/secret-crypto', () => ({
+  encryptSecret: vi.fn((s: string) => `enc:${s}`),
+  decryptSecret: vi.fn((s: string) => s.replace(/^enc:/, '')),
+}));
+
+vi.mock('../lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
 
 import { webhooksRouter } from './webhook.router';
-import { addTransaction, writeStore, Store } from '../common/storage';
 import { signPayload } from './webhook.service';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+const TEST_API_KEY = 'test-api-key';
+const TEST_JWT_SECRET = 'test-jwt-secret';
+
+// Valid Stellar addresses deterministically derived from fixed seeds.
+const SELLER_A = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 0xa1)).publicKey();
+const SELLER_B = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 0xa2)).publicKey();
+
+/** Build a minimal valid HS256 seller JWT. */
+function makeSellerJwt(sellerWallet: string, secret: string, ttlSeconds = 3600): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sellerWallet,
+      exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+      iat: Math.floor(Date.now() / 1000),
+    }),
+  ).toString('base64url');
+  const sig = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+const apiKeyHeader = () => ({ Authorization: `Bearer ${TEST_API_KEY}` });
+const jwtHeader = (wallet: string) => ({
+  Authorization: `Bearer ${makeSellerJwt(wallet, TEST_JWT_SECRET)}`,
+});
+
+// ── Test suite ─────────────────────────────────────────────────────────────
 
 describe('Webhook Router', () => {
   let app: Express;
 
-  beforeEach(async () => {
-    // Clear mock transactions
-    const storage = (await import('../common/storage')) as { _clearMockTransactions?: () => void };
-    if (storage._clearMockTransactions) {
-      storage._clearMockTransactions();
-    }
-
-    // Seed clean store
-    const clean: Store = { datasets: [], transactions: [], webhooks: [], payoutFailures: [] };
-    await writeStore(clean);
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
 
     app = express();
     app.use(express.json());
     app.use('/api/v1/webhooks', webhooksRouter);
 
     process.env.PAYMENT_WEBHOOK_SECRET = 'test-secret';
+    process.env.API_KEY = TEST_API_KEY;
+    process.env.SELLER_JWT_SECRET = TEST_JWT_SECRET;
   });
 
-  afterEach(async () => {
-    await writeStore({ datasets: [], transactions: [], webhooks: [], payoutFailures: [] });
+  afterEach(() => {
+    delete process.env.API_KEY;
+    delete process.env.SELLER_JWT_SECRET;
+    delete process.env.PAYMENT_WEBHOOK_SECRET;
   });
+
+  // ── POST /payment ──────────────────────────────────────────────────────────
 
   describe('POST /api/v1/webhooks/payment', () => {
-    const validPayload = {
-      txHash: '0x123',
-      memo: 'haz-dataset1-12345',
-    };
+    const validPayload = { txHash: '0x123', memo: 'haz-dataset1-12345' };
 
     it('processes valid signed webhook', async () => {
-      // Setup pending transaction
-      await addTransaction({
+      _transactions.push({
         id: 'tx-1',
         datasetId: 'dataset1',
         txHash: '',
@@ -90,11 +174,8 @@ describe('Webhook Router', () => {
         timestamp: new Date().toISOString(),
       });
 
-      // Wait for storage to be written
-      await new Promise(resolve => setTimeout(resolve, 100));
-
       const bodyString = JSON.stringify(validPayload);
-      const signature = signPayload(bodyString, 'test-secret');
+      const signature = (signPayload as ReturnType<typeof vi.fn>)(bodyString, 'test-secret');
 
       const res = await request(app)
         .post('/api/v1/webhooks/payment')
@@ -118,14 +199,13 @@ describe('Webhook Router', () => {
 
     it('rejects missing signature', async () => {
       const res = await request(app).post('/api/v1/webhooks/payment').send(validPayload);
-
       expect(res.status).toBe(401);
       expect(res.body.error).toBe('Missing signature');
     });
 
     it('returns 404 if transaction not found by memo', async () => {
       const payload = { txHash: '0x456', memo: 'unknown-memo' };
-      const signature = signPayload(JSON.stringify(payload), 'test-secret');
+      const signature = (signPayload as ReturnType<typeof vi.fn>)(JSON.stringify(payload), 'test-secret');
 
       const res = await request(app)
         .post('/api/v1/webhooks/payment')
@@ -137,19 +217,22 @@ describe('Webhook Router', () => {
     });
   });
 
+  // ── POST / (register) ──────────────────────────────────────────────────────
+
   describe('POST /api/v1/webhooks', () => {
     it('registers a webhook with valid data', async () => {
       const res = await request(app)
         .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
         .send({
-          sellerWallet: 'G123',
+          sellerWallet: SELLER_A,
           url: 'https://example.com/webhook',
           secret: 'supersecret',
           events: ['payment.received', 'dataset.created'],
         });
       expect(res.status).toBe(201);
       expect(res.body.success).toBe(true);
-      expect(res.body.webhook.sellerWallet).toBe('G123');
+      expect(res.body.webhook.sellerWallet).toBe(SELLER_A);
       expect(res.body.webhook.url).toBe('https://example.com/webhook');
       expect(res.body.webhook.events).toEqual(['payment.received', 'dataset.created']);
       expect(res.body.webhook.active).toBe(true);
@@ -157,30 +240,28 @@ describe('Webhook Router', () => {
     });
 
     it('rejects missing sellerWallet', async () => {
-      const res = await request(app).post('/api/v1/webhooks').send({
-        url: 'https://example.com/webhook',
-        secret: 'shh',
-      });
+      const res = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ url: 'https://example.com/webhook', secret: 'shh' });
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('sellerWallet');
     });
 
     it('rejects invalid URL', async () => {
-      const res = await request(app).post('/api/v1/webhooks').send({
-        sellerWallet: 'G123',
-        url: 'not-a-url',
-        secret: 'shh',
-      });
+      const res = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'not-a-url', secret: 'shh' });
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('Invalid URL');
     });
 
     it('rejects non-http(s) URL', async () => {
-      const res = await request(app).post('/api/v1/webhooks').send({
-        sellerWallet: 'G123',
-        url: 'ftp://example.com/hook',
-        secret: 'shh',
-      });
+      const res = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'ftp://example.com/hook', secret: 'shh' });
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('http or https');
     });
@@ -188,8 +269,9 @@ describe('Webhook Router', () => {
     it('rejects invalid event names', async () => {
       const res = await request(app)
         .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
         .send({
-          sellerWallet: 'G123',
+          sellerWallet: SELLER_A,
           url: 'https://example.com/webhook',
           secret: 'shh',
           events: ['invalid.event'],
@@ -197,75 +279,125 @@ describe('Webhook Router', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('Invalid events');
     });
+
+    it('rejects request with no API key', async () => {
+      const res = await request(app)
+        .post('/api/v1/webhooks')
+        .send({ sellerWallet: SELLER_A, url: 'https://x.com', secret: 'shh' });
+      expect(res.status).toBe(401);
+    });
   });
 
+  // ── GET /:sellerWallet ─────────────────────────────────────────────────────
+
   describe('GET /api/v1/webhooks/:sellerWallet', () => {
-    it('lists webhooks for a seller without secrets', async () => {
+    it('lists webhooks for a seller without secrets (API key)', async () => {
       await request(app)
         .post('/api/v1/webhooks')
-        .send({
-          sellerWallet: 'GABC',
-          url: 'https://a.com/hook',
-          secret: 'secret-a',
-          events: ['ping'],
-        });
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://a.com/hook', secret: 'secret-a', events: ['ping'] });
 
-      const res = await request(app).get('/api/v1/webhooks/GABC');
+      const res = await request(app).get(`/api/v1/webhooks/${SELLER_A}`).set(apiKeyHeader());
       expect(res.status).toBe(200);
       expect(res.body.webhooks.length).toBe(1);
       expect(res.body.webhooks[0].secret).toBeUndefined();
     });
 
     it('returns empty array for unknown seller', async () => {
-      const res = await request(app).get('/api/v1/webhooks/GUNKNOWN');
+      const res = await request(app).get(`/api/v1/webhooks/${SELLER_B}`).set(apiKeyHeader());
       expect(res.status).toBe(200);
       expect(res.body.webhooks).toEqual([]);
     });
+
+    it('rejects unauthenticated request with 401', async () => {
+      const res = await request(app).get(`/api/v1/webhooks/${SELLER_A}`);
+      expect(res.status).toBe(401);
+    });
+
+    it('allows seller JWT scoped to matching wallet', async () => {
+      await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://a.com/hook', secret: 'shh', events: ['ping'] });
+
+      const res = await request(app).get(`/api/v1/webhooks/${SELLER_A}`).set(jwtHeader(SELLER_A));
+      expect(res.status).toBe(200);
+      expect(res.body.webhooks.length).toBe(1);
+    });
+
+    it('rejects seller JWT scoped to a different wallet with 403', async () => {
+      const res = await request(app).get(`/api/v1/webhooks/${SELLER_A}`).set(jwtHeader(SELLER_B));
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain('wallet');
+    });
   });
 
+  // ── DELETE /:id ────────────────────────────────────────────────────────────
+
   describe('DELETE /api/v1/webhooks/:id', () => {
-    it('deletes an existing webhook', async () => {
-      const create = await request(app).post('/api/v1/webhooks').send({
-        sellerWallet: 'G123',
-        url: 'https://example.com/webhook',
-        secret: 'shh',
-      });
+    it('deletes an existing webhook (API key)', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
       const id = create.body.webhook.id;
 
-      const del = await request(app).delete(`/api/v1/webhooks/${id}`);
+      const del = await request(app).delete(`/api/v1/webhooks/${id}`).set(apiKeyHeader());
       expect(del.status).toBe(200);
       expect(del.body.success).toBe(true);
 
-      const list = await request(app).get('/api/v1/webhooks/G123');
+      const list = await request(app).get(`/api/v1/webhooks/${SELLER_A}`).set(apiKeyHeader());
       expect(list.body.webhooks.length).toBe(0);
     });
 
+    it('deletes own webhook with seller JWT', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
+      const id = create.body.webhook.id;
+
+      const del = await request(app).delete(`/api/v1/webhooks/${id}`).set(jwtHeader(SELLER_A));
+      expect(del.status).toBe(200);
+    });
+
+    it('returns 403 when seller JWT belongs to a different seller', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
+      const id = create.body.webhook.id;
+
+      const del = await request(app).delete(`/api/v1/webhooks/${id}`).set(jwtHeader(SELLER_B));
+      expect(del.status).toBe(403);
+      expect(del.body.error).toContain('Not authorized');
+    });
+
     it('returns 404 for non-existent webhook', async () => {
-      const res = await request(app).delete('/api/v1/webhooks/wh-nonexistent');
+      const res = await request(app).delete('/api/v1/webhooks/wh-nonexistent').set(apiKeyHeader());
       expect(res.status).toBe(404);
+    });
+
+    it('rejects unauthenticated request with 401', async () => {
+      const res = await request(app).delete('/api/v1/webhooks/wh-nonexistent');
+      expect(res.status).toBe(401);
     });
   });
 
+  // ── PATCH /:id ─────────────────────────────────────────────────────────────
+
   describe('PATCH /api/v1/webhooks/:id', () => {
-    it('updates webhook fields', async () => {
+    it('updates webhook fields (API key)', async () => {
       const create = await request(app)
         .post('/api/v1/webhooks')
-        .send({
-          sellerWallet: 'G123',
-          url: 'https://old.com/hook',
-          secret: 'oldsecret',
-          events: ['ping'],
-        });
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://old.com/hook', secret: 'oldsecret', events: ['ping'] });
       const id = create.body.webhook.id;
 
       const patch = await request(app)
         .patch(`/api/v1/webhooks/${id}`)
-        .send({
-          url: 'https://new.com/hook',
-          secret: 'newsecret',
-          events: ['payment.received'],
-          active: false,
-        });
+        .set(apiKeyHeader())
+        .send({ url: 'https://new.com/hook', secret: 'newsecret', events: ['payment.received'], active: false });
       expect(patch.status).toBe(200);
       expect(patch.body.webhook.url).toBe('https://new.com/hook');
       expect(patch.body.webhook.events).toEqual(['payment.received']);
@@ -273,58 +405,121 @@ describe('Webhook Router', () => {
       expect(patch.body.webhook.secret).toBeUndefined();
     });
 
-    it('rejects invalid URL on patch', async () => {
-      const create = await request(app).post('/api/v1/webhooks').send({
-        sellerWallet: 'G123',
-        url: 'https://old.com/hook',
-        secret: 'oldsecret',
-      });
+    it('updates own webhook with seller JWT', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://old.com/hook', secret: 'oldsecret' });
       const id = create.body.webhook.id;
 
-      const patch = await request(app).patch(`/api/v1/webhooks/${id}`).send({
-        url: 'bad-url',
-      });
+      const patch = await request(app)
+        .patch(`/api/v1/webhooks/${id}`)
+        .set(jwtHeader(SELLER_A))
+        .send({ url: 'https://new.com/hook' });
+      expect(patch.status).toBe(200);
+      expect(patch.body.webhook.url).toBe('https://new.com/hook');
+    });
+
+    it('returns 403 when seller JWT belongs to a different seller', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://old.com/hook', secret: 'oldsecret' });
+      const id = create.body.webhook.id;
+
+      const patch = await request(app)
+        .patch(`/api/v1/webhooks/${id}`)
+        .set(jwtHeader(SELLER_B))
+        .send({ url: 'https://attacker.com/hook' });
+      expect(patch.status).toBe(403);
+      expect(patch.body.error).toContain('Not authorized');
+    });
+
+    it('rejects invalid URL on patch', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://old.com/hook', secret: 'oldsecret' });
+      const id = create.body.webhook.id;
+
+      const patch = await request(app)
+        .patch(`/api/v1/webhooks/${id}`)
+        .set(apiKeyHeader())
+        .send({ url: 'bad-url' });
       expect(patch.status).toBe(400);
     });
 
     it('returns 404 for non-existent webhook', async () => {
-      const res = await request(app).patch('/api/v1/webhooks/wh-xyz').send({ active: false });
+      const res = await request(app).patch('/api/v1/webhooks/wh-xyz').set(apiKeyHeader()).send({ active: false });
       expect(res.status).toBe(404);
+    });
+
+    it('rejects unauthenticated request with 401', async () => {
+      const res = await request(app).patch('/api/v1/webhooks/wh-xyz').send({ active: false });
+      expect(res.status).toBe(401);
     });
   });
 
+  // ── POST /:id/test ─────────────────────────────────────────────────────────
+
   describe('POST /api/v1/webhooks/:id/test', () => {
-    it('returns success for test ping (non-blocking)', async () => {
-      const create = await request(app).post('/api/v1/webhooks').send({
-        sellerWallet: 'G123',
-        url: 'https://example.com/webhook',
-        secret: 'shh',
-      });
+    it('returns success for test ping (API key)', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
       const id = create.body.webhook.id;
 
-      const res = await request(app).post(`/api/v1/webhooks/${id}/test`);
+      const res = await request(app).post(`/api/v1/webhooks/${id}/test`).set(apiKeyHeader());
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
     });
 
-    it('returns 400 for inactive webhook', async () => {
-      const create = await request(app).post('/api/v1/webhooks').send({
-        sellerWallet: 'G123',
-        url: 'https://example.com/webhook',
-        secret: 'shh',
-      });
+    it('allows owner to trigger test via seller JWT', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
       const id = create.body.webhook.id;
 
-      await request(app).patch(`/api/v1/webhooks/${id}`).send({ active: false });
+      const res = await request(app).post(`/api/v1/webhooks/${id}/test`).set(jwtHeader(SELLER_A));
+      expect(res.status).toBe(200);
+    });
 
-      const res = await request(app).post(`/api/v1/webhooks/${id}/test`);
+    it('returns 403 when seller JWT belongs to a different seller', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
+      const id = create.body.webhook.id;
+
+      const res = await request(app).post(`/api/v1/webhooks/${id}/test`).set(jwtHeader(SELLER_B));
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain('Not authorized');
+    });
+
+    it('returns 400 for inactive webhook', async () => {
+      const create = await request(app)
+        .post('/api/v1/webhooks')
+        .set(apiKeyHeader())
+        .send({ sellerWallet: SELLER_A, url: 'https://example.com/webhook', secret: 'shh' });
+      const id = create.body.webhook.id;
+
+      await request(app).patch(`/api/v1/webhooks/${id}`).set(apiKeyHeader()).send({ active: false });
+
+      const res = await request(app).post(`/api/v1/webhooks/${id}/test`).set(apiKeyHeader());
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('inactive');
     });
 
     it('returns 404 for non-existent webhook', async () => {
-      const res = await request(app).post('/api/v1/webhooks/wh-ghost/test');
+      const res = await request(app).post('/api/v1/webhooks/wh-ghost/test').set(apiKeyHeader());
       expect(res.status).toBe(404);
+    });
+
+    it('rejects unauthenticated request with 401', async () => {
+      const res = await request(app).post('/api/v1/webhooks/wh-ghost/test');
+      expect(res.status).toBe(401);
     });
   });
 });

--- a/backend/src/webhooks/webhook.router.ts
+++ b/backend/src/webhooks/webhook.router.ts
@@ -12,9 +12,14 @@ import {
 } from '../common/storage';
 import { validateBody } from '../common/validate';
 import { notifySeller, signPayload } from './webhook.service';
-import { requireApiKey } from '../common/auth.middleware';
+import {
+  requireApiKey,
+  requireSellerMutationAuth,
+  requireSellerReadAuth,
+} from '../common/auth.middleware';
 import { encryptSecret } from '../common/secret-crypto';
 import { processPayment } from '../payments/payments.service';
+import { logger } from '../lib/logger';
 
 /**
  * @openapi
@@ -297,7 +302,8 @@ webhooksRouter.post(
  *                     $ref: '#/components/schemas/Webhook'
  */
 // GET /api/webhooks/:sellerWallet — list webhooks for a seller
-webhooksRouter.get('/:sellerWallet', async (req: Request, res: Response) => {
+// Requires shared API key (admin) OR seller JWT scoped to this wallet.
+webhooksRouter.get('/:sellerWallet', requireSellerReadAuth, async (req: Request, res: Response) => {
   const webhooks = await getWebhooksForSeller(req.params.sellerWallet);
   return res.json({
     success: true,
@@ -323,10 +329,14 @@ webhooksRouter.get('/:sellerWallet', async (req: Request, res: Response) => {
  *         description: Webhook not found
  */
 // DELETE /api/webhooks/:id — remove a webhook
-webhooksRouter.delete('/:id', requireApiKey, async (req: Request, res: Response) => {
+// When authenticated via seller JWT, only the owning seller may delete their webhook.
+webhooksRouter.delete('/:id', requireSellerMutationAuth, async (req: Request, res: Response) => {
   const webhook = await getWebhookById(req.params.id);
   if (!webhook) {
     return res.status(404).json({ error: 'Webhook not found' });
+  }
+  if (req.sellerAuth && req.sellerAuth.sellerWallet !== webhook.sellerWallet) {
+    return res.status(403).json({ error: 'Not authorized to delete this webhook' });
   }
   await removeWebhook(req.params.id);
   return res.json({ success: true, message: 'Webhook deleted' });
@@ -352,12 +362,15 @@ webhooksRouter.delete('/:id', requireApiKey, async (req: Request, res: Response)
  *         description: Webhook not found
  */
 // POST /api/webhooks/:id/test — send a test ping event
-webhooksRouter.post('/:id/test', requireApiKey, async (req: Request, res: Response) => {
+// When authenticated via seller JWT, only the owning seller may trigger a test.
+webhooksRouter.post('/:id/test', requireSellerMutationAuth, async (req: Request, res: Response) => {
   const webhook = await getWebhookById(req.params.id);
   if (!webhook) {
     return res.status(404).json({ error: 'Webhook not found' });
   }
-
+  if (req.sellerAuth && req.sellerAuth.sellerWallet !== webhook.sellerWallet) {
+    return res.status(403).json({ error: 'Not authorized to test this webhook' });
+  }
   if (!webhook.active) {
     return res.status(400).json({ error: 'Webhook is inactive' });
   }
@@ -417,14 +430,18 @@ webhooksRouter.post('/:id/test', requireApiKey, async (req: Request, res: Respon
  *         description: Webhook not found
  */
 // PATCH /api/webhooks/:id — update webhook (url, secret, events, active)
+// When authenticated via seller JWT, only the owning seller may update their webhook.
 webhooksRouter.patch(
   '/:id',
-  requireApiKey,
+  requireSellerMutationAuth,
   validateBody(updateWebhookSchema),
   async (req: Request, res: Response) => {
     const webhook = await getWebhookById(req.params.id);
     if (!webhook) {
       return res.status(404).json({ error: 'Webhook not found' });
+    }
+    if (req.sellerAuth && req.sellerAuth.sellerWallet !== webhook.sellerWallet) {
+      return res.status(403).json({ error: 'Not authorized to update this webhook' });
     }
 
     const updates = req.body as z.infer<typeof updateWebhookSchema>;


### PR DESCRIPTION
Closes #495

## What changed

Deleted the naive `ratingSchema` route handler that was registered first for `POST /:id/ratings` in `datasets.router.ts`. Because Express dispatches to the first matching route and stops, this handler was blocking the verified `createRatingSchema` handler that came after it — making it dead code.

The removed handler:
- Accepted a bare `{ score }` from **anyone**, no purchase check
- Updated `ratings.{ score, count }` directly, never populating `ratings.reviews[]`
- Had no de-duplication, enabling unlimited spam-rating

The verified handler (now the sole registration) is unchanged — it requires:
- `txHash` from a `delivered` transaction for the requested dataset
- Unique `txHash` per review (409 on duplicate)
- Stores the review in `ratings.reviews[]` which `GET /:id/ratings` paginates

## Why

A caller with no purchase history could POST arbitrary scores, silently bypassing the verified handler. The first-registered route always wins in Express.

## How to test

```bash
cd backend
npm install
npm run test -- src/datasets/datasets.router.test.ts
```

29 tests pass, including 12 new tests for the `POST` and `GET` ratings routes covering: valid rating, comment, missing txHash → 400, out-of-range score → 400, unknown txHash → 403, wrong dataset → 403, undelivered tx → 403, duplicate txHash → 409, GET empty/populated/404.