### PR TITLE
docs: replace PLATFORM_FEE_BPS with PLATFORM_FEE_RATE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,5 +47,5 @@ ESCROW_CONTRACT_ID=CCPG2CSL6WDUA2IFUDHFN5SCJQUTFCLFKMTARALQ5RWGB2RGG345HEEH
 USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 
 # ── Platform Fee ───────────────────────────────
-# Basis points taken by the platform on each sale (500 = 5%).
-PLATFORM_FEE_BPS=500
+# Fraction of every sale the platform keeps, in [0, 1] (0.05 = 5%).
+PLATFORM_FEE_RATE=0.05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,8 +229,8 @@ type AsyncState<T> =
 const sellerAmount = dataset.pricePerQuery * 0.95;
 
 // Good
-import { PLATFORM_FEE_BPS } from '../lib/constants';
-const sellerAmount = dataset.pricePerQuery * (1 - PLATFORM_FEE_BPS / 10_000);
+import { PLATFORM_FEE_RATE } from '../lib/constants';
+const sellerAmount = dataset.pricePerQuery * (1 - PLATFORM_FEE_RATE);
 ```
 
 ### Rust / Smart Contract


### PR DESCRIPTION
### Description

Closes #503

The Express backend reads the `PLATFORM_FEE_RATE` environment variable (a decimal fraction in the range `[0, 1]`, defaulting to `0.05`) to configure the platform fee split, but `.env.example` documented the obsolete `PLATFORM_FEE_BPS` (basis points). Anyone configuring the platform fee using the example variable would see no change.

This PR cleans up the configuration files and guides to match the code implementation.

### Changes Made

- **[.env.example](file:///Users/aliphatic/Desktop/Hazina-Escrow/.env.example)**: Replaced `PLATFORM_FEE_BPS=500` with `PLATFORM_FEE_RATE=0.05` along with a comment clarifying the `[0, 1]` fraction range.
- **[CONTRIBUTING.md](file:///Users/aliphatic/Desktop/Hazina-Escrow/CONTRIBUTING.md)**: Updated the code guidelines example from using `PLATFORM_FEE_BPS` to using `PLATFORM_FEE_RATE`.

### Verification

- Confirmed with `grep` that there are no remaining references to `PLATFORM_FEE_BPS` anywhere in the repository.
- Verified that formatting check and structure remain valid.
